### PR TITLE
FactorySystem

### DIFF
--- a/src/IFactory.h
+++ b/src/IFactory.h
@@ -1,0 +1,23 @@
+#ifndef IFACTORY_H
+#define IFACTORY_H
+
+#include <functional>
+#include <vector>
+#include <map>
+#include "Property.h"
+
+class IFactory
+{
+    public:
+        typedef std::function<void( const std::string,
+                                    const unsigned int,
+                                    std::vector<Property>&)> FactoryFunction;
+        IFactory(){};
+        virtual ~IFactory(){};
+        virtual std::map<std::string,FactoryFunction>
+                getFactoryFunctions()=0;
+    protected:
+    private:
+};
+
+#endif // IFACTORY_H

--- a/src/IFactory.h
+++ b/src/IFactory.h
@@ -14,6 +14,12 @@ class IFactory
                                     std::vector<Property>&)> FactoryFunction;
         IFactory(){};
         virtual ~IFactory(){};
+        /**
+         * \brief Returns the list of Factory functions and types they create
+         *
+         *
+         * \returns std::map<std::string, FactoryFunction> Contains Callbacks for different Component types that can be created by this class
+         */
         virtual std::map<std::string,FactoryFunction>
                 getFactoryFunctions()=0;
     protected:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 
 #include "systems/OpenGLSystem.h"
 #include "systems/SimplePhysics.h"
+#include "systems/FactorySystem.h"
 #include "controllers/GLSixDOFViewController.h"
 #include "components/ViewMover.h"
 #include "SCParser.h"
@@ -14,6 +15,9 @@
 
 int main(int argCount, char **argValues) {
 	OpenGLSystem glsys;
+	SimplePhysics physys;
+	FactorySystem::getInstance().register_Factory(&glsys);
+	FactorySystem::getInstance().register_Factory(&physys);
 	IOpSys* os = nullptr;
 #ifdef OS_Win32
 	os = new win32();
@@ -39,14 +43,15 @@ int main(int argCount, char **argValues) {
 	for (unsigned int i = 0; i < parser.EntityCount(); ++i) {
 		const Sigma::parser::Entity* e = parser.GetEntity(i);
 		for (auto itr = e->components.begin(); itr != e->components.end(); ++itr) {
-			glsys.Factory(itr->type, e->id, const_cast<std::vector<Property>&>(itr->properties));
+            FactorySystem::getInstance().create(
+                        itr->type,e->id,
+                        const_cast<std::vector<Property>&>(itr->properties));
 		}
 	}
 
-	SimplePhysics physys;
-
 	std::vector<Property> props;
-	ViewMover* mover = reinterpret_cast<ViewMover*>(physys.Factory("ViewMover", 9, props));
+	physys.Factory("ViewMover", 9, props);
+	ViewMover* mover = reinterpret_cast<ViewMover*>(physys.GetComponent(9));
 
 	Sigma::event::handler::GLSixDOFViewController cameraController(glsys.View(), mover);
 	IOpSys::KeyboardEventSystem.Register(&cameraController);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argCount, char **argValues) {
 	}
 
 	std::vector<Property> props;
-	physys.Factory("ViewMover", 9, props);
+	physys.createViewMover("ViewMover", 9, props);
 	ViewMover* mover = reinterpret_cast<ViewMover*>(physys.GetComponent(9));
 
 	Sigma::event::handler::GLSixDOFViewController cameraController(glsys.View(), mover);

--- a/src/systems/FactorySystem.cpp
+++ b/src/systems/FactorySystem.cpp
@@ -1,0 +1,47 @@
+#include "FactorySystem.h"
+#include <iostream>
+
+std::shared_ptr<FactorySystem> FactorySystem::_instance;
+std::once_flag FactorySystem::only_once;
+
+FactorySystem::FactorySystem()
+{
+    //ctor
+}
+
+FactorySystem::~FactorySystem()
+{
+    //dtor
+}
+
+FactorySystem& FactorySystem::getInstance()
+{
+    std::call_once( FactorySystem::only_once,
+        [] ()
+		{
+		   FactorySystem::_instance.reset( new FactorySystem() );
+        });
+    return *FactorySystem::_instance;
+}
+
+void FactorySystem::create(const std::string type,
+                           const unsigned int entityID,
+                           std::vector<Property> &properties)
+{
+    if(registeredFactoryFunctions.find(type)!=
+       registeredFactoryFunctions.end())
+    {
+        registeredFactoryFunctions[type](type,entityID,properties);
+    }else
+    {
+        std::cerr << "Error: Couldn't create Component:" << type  << std::endl;
+    }
+}
+
+void FactorySystem::register_Factory(IFactory* Factory)
+{
+    for(auto& FactoryFunc : Factory->getFactoryFunctions())
+    {
+        registeredFactoryFunctions[FactoryFunc.first]=FactoryFunc.second;
+    }
+}

--- a/src/systems/FactorySystem.h
+++ b/src/systems/FactorySystem.h
@@ -1,0 +1,28 @@
+#ifndef FACTORYSYSTEM_H
+#define FACTORYSYSTEM_H
+#include "../IFactory.h"
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+class FactorySystem
+{
+    public:
+        static FactorySystem& getInstance();
+        ~FactorySystem();
+        void create(const std::string type,
+                    const unsigned int entityID,
+                    std::vector<Property> &properties);
+        void register_Factory(IFactory* Factory);
+    protected:
+    private:
+        FactorySystem();
+        FactorySystem(const FactorySystem& rhs) = delete;
+        FactorySystem& operator=(const FactorySystem& rhs) = delete;
+        static std::shared_ptr<FactorySystem> _instance;
+        static std::once_flag only_once;
+        std::unordered_map<std::string,IFactory::FactoryFunction>
+                registeredFactoryFunctions;
+};
+
+#endif // FACTORYSYSTEM_H

--- a/src/systems/FactorySystem.h
+++ b/src/systems/FactorySystem.h
@@ -10,6 +10,15 @@ class FactorySystem
     public:
         static FactorySystem& getInstance();
         ~FactorySystem();
+        /**
+         * \brief Create a new components of a given type.
+         *
+         * A factory method to create various components and add them to the system. These components will be used during the system update method
+         * \param[in] const std::string type The type of componenet to create
+         * \param[in] const int entityID The ID of the entity this component belongs to.
+         * \param[in] std::vector<Property> &properties A vector containing the properties to apply to the created component.
+         * \returns   IComponent* The newly create component
+         */
         void create(const std::string type,
                     const unsigned int entityID,
                     std::vector<Property> &properties);

--- a/src/systems/OpenGLSystem.cpp
+++ b/src/systems/OpenGLSystem.cpp
@@ -7,7 +7,7 @@
 #include "../components/GLMesh.h"
 
 OpenGLSystem::OpenGLSystem() : windowWidth(800), windowHeight(600), deltaAccumulator(0.0) {
-	this->view = new GLSixDOFView(); 
+	this->view = new GLSixDOFView();
 }
 
 OpenGLSystem::~OpenGLSystem() {
@@ -19,7 +19,21 @@ OpenGLSystem::~OpenGLSystem() {
 	}
 }
 
-IGLComponent* OpenGLSystem::Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
+std::map<std::string,IFactory::FactoryFunction>
+        OpenGLSystem::getFactoryFunctions()
+{
+    using namespace std::placeholders;
+    std::map<std::string,IFactory::FactoryFunction> retval=
+    {
+        {"GLSprite",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)},
+        {"GLIcoSphere",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)},
+        {"GLCubeSphere",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)},
+        {"GLMesh",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)}
+    };
+    return retval;
+}
+
+void OpenGLSystem::Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
 	if (type == "GLSprite") {
 		GLSprite* spr = new GLSprite(entityID);
 		spr->InitializeBuffers();
@@ -28,7 +42,6 @@ IGLComponent* OpenGLSystem::Factory(const std::string type, const unsigned int e
 		}
 		this->components[entityID][0] = spr;
 		spr->Transform()->Translate(0,0,0);
-		return spr;
 	} else if (type == "GLIcoSphere") {
 		GLIcoSphere* sphere = new GLIcoSphere(entityID);
 		sphere->InitializeBuffers();
@@ -58,7 +71,6 @@ IGLComponent* OpenGLSystem::Factory(const std::string type, const unsigned int e
 		sphere->Transform()->Scale(scale,scale,scale);
 		sphere->Transform()->Translate(x,y,z);
 		this->components[entityID][componentID] = sphere;
-		return sphere;
 	} else if (type == "GLCubeSphere") {
 		GLCubeSphere* sphere = new GLCubeSphere(entityID);
 		sphere->InitializeBuffers();
@@ -88,7 +100,6 @@ IGLComponent* OpenGLSystem::Factory(const std::string type, const unsigned int e
 		sphere->Transform()->Scale(scale,scale,scale);
 		sphere->Transform()->Translate(x,y,z);
 		this->components[entityID][componentID] = sphere;
-		return sphere;
 	} else if (type=="GLMesh") {
 		GLMesh* mesh = new GLMesh(entityID);
 		float scale = 1.0f;
@@ -121,7 +132,6 @@ IGLComponent* OpenGLSystem::Factory(const std::string type, const unsigned int e
 		mesh->Transform()->Translate(x,y,z);
 		this->components[entityID][componentID] = mesh;
 	}
-	return nullptr;
 }
 
 bool OpenGLSystem::Update(const double delta) {
@@ -131,7 +141,7 @@ bool OpenGLSystem::Update(const double delta) {
 		this->view->UpdateViewMatrix();
 		// Set up the scene to a "clean" state.
 		glClearColor(0.0f,0.0f,0.0f,0.0f);
-		glViewport(0, 0, windowWidth, windowHeight); // Set the viewport size to fill the window  
+		glViewport(0, 0, windowWidth, windowHeight); // Set the viewport size to fill the window
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT); // Clear required buffers
 
 		// Set the ViewProjection matrix to be used in the shader.

--- a/src/systems/OpenGLSystem.cpp
+++ b/src/systems/OpenGLSystem.cpp
@@ -25,16 +25,15 @@ std::map<std::string,IFactory::FactoryFunction>
     using namespace std::placeholders;
     std::map<std::string,IFactory::FactoryFunction> retval=
     {
-        {"GLSprite",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)},
-        {"GLIcoSphere",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)},
-        {"GLCubeSphere",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)},
-        {"GLMesh",std::bind(&OpenGLSystem::Factory,this,_1,_2,_3)}
+        {"GLSprite",std::bind(&OpenGLSystem::createGLSprite,this,_1,_2,_3)},
+        {"GLIcoSphere",std::bind(&OpenGLSystem::createGLIcoSphere,this,_1,_2,_3)},
+        {"GLCubeSphere",std::bind(&OpenGLSystem::createGLCubeSphere,this,_1,_2,_3)},
+        {"GLMesh",std::bind(&OpenGLSystem::createGLMesh,this,_1,_2,_3)}
     };
     return retval;
 }
 
-void OpenGLSystem::Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
-	if (type == "GLSprite") {
+void OpenGLSystem::createGLSprite(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
 		GLSprite* spr = new GLSprite(entityID);
 		spr->InitializeBuffers();
 		if (entityID == 2) {
@@ -42,7 +41,9 @@ void OpenGLSystem::Factory(const std::string type, const unsigned int entityID, 
 		}
 		this->components[entityID][0] = spr;
 		spr->Transform()->Translate(0,0,0);
-	} else if (type == "GLIcoSphere") {
+}
+
+void OpenGLSystem::createGLIcoSphere(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
 		GLIcoSphere* sphere = new GLIcoSphere(entityID);
 		sphere->InitializeBuffers();
 		float scale = 1.0f;
@@ -71,7 +72,9 @@ void OpenGLSystem::Factory(const std::string type, const unsigned int entityID, 
 		sphere->Transform()->Scale(scale,scale,scale);
 		sphere->Transform()->Translate(x,y,z);
 		this->components[entityID][componentID] = sphere;
-	} else if (type == "GLCubeSphere") {
+}
+
+void OpenGLSystem::createGLCubeSphere(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
 		GLCubeSphere* sphere = new GLCubeSphere(entityID);
 		sphere->InitializeBuffers();
 		float scale = 1.0f;
@@ -100,8 +103,9 @@ void OpenGLSystem::Factory(const std::string type, const unsigned int entityID, 
 		sphere->Transform()->Scale(scale,scale,scale);
 		sphere->Transform()->Translate(x,y,z);
 		this->components[entityID][componentID] = sphere;
-	} else if (type=="GLMesh") {
-		GLMesh* mesh = new GLMesh(entityID);
+}
+void OpenGLSystem::createGLMesh(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
+        GLMesh* mesh = new GLMesh(entityID);
 		float scale = 1.0f;
 		float x = 0.0f;
 		float y = 0.0f;
@@ -131,7 +135,6 @@ void OpenGLSystem::Factory(const std::string type, const unsigned int entityID, 
 		mesh->Transform()->Scale(scale,scale,scale);
 		mesh->Transform()->Translate(x,y,z);
 		this->components[entityID][componentID] = mesh;
-	}
 }
 
 bool OpenGLSystem::Update(const double delta) {

--- a/src/systems/OpenGLSystem.h
+++ b/src/systems/OpenGLSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Property.h"
+#include "../IFactory.h"
 
 #include "GL/glew.h"
 #include "glm/glm.hpp"
@@ -9,7 +10,8 @@
 struct IGLView;
 class IGLComponent;
 
-class OpenGLSystem {
+class OpenGLSystem
+    : public IFactory {
 public:
 	OpenGLSystem();
 
@@ -26,6 +28,8 @@ public:
 	 */
 	const int* Start();
 
+
+    std::map<std::string,FactoryFunction> getFactoryFunctions();
 	/**
 	 * \brief A factory to create new components of a given type.
 	 *
@@ -35,7 +39,7 @@ public:
 	 * \param[in] std::vector<Property> &properties A vector containing the properties to apply to the created component.
 	 * \returns   IComponent* The newly create component
 	 */
-	IGLComponent* Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
+	void Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
 
 	/**
 	 * \brief Causes an update in the system based on the change in time.
@@ -48,7 +52,7 @@ public:
 
 	/**
 	 * \brief Retrieve the component that belongs to the given entity ID
-	 * 
+	 *
 	 * \param[in] const unsigned int entityID
 	 * \param[in] const unsigned int componentID
 	 * \returns   IComponent* The component that belongs to the entity ID or nullptr if no component exists for the given ID.
@@ -62,7 +66,7 @@ public:
 	 * \param[in/out] float x
 	 * \param[in/out] float y
 	 * \param[in/out] float z
-	 * \returns   void 
+	 * \returns   void
 	 */
 	void Move(float x, float y, float z);
 
@@ -88,8 +92,8 @@ public:
 
 	IGLView* View() const { return view; }
 private:
-	unsigned int windowWidth; // Store the width of our window  
-	unsigned int windowHeight; // Store the height of our window 
+	unsigned int windowWidth; // Store the width of our window
+	unsigned int windowHeight; // Store the height of our window
 
 	GLuint m_vaoID[2]; // two vertex array objects, one for each drawn object
 	GLuint m_vboID[3]; // three VBOs

--- a/src/systems/OpenGLSystem.h
+++ b/src/systems/OpenGLSystem.h
@@ -28,19 +28,6 @@ public:
 	 */
 	const int* Start();
 
-
-    std::map<std::string,FactoryFunction> getFactoryFunctions();
-	/**
-	 * \brief A factory to create new components of a given type.
-	 *
-	 * A factory method to create various components and add them to the system. These components will be used during the system update method
-	 * \param[in] const std::string type The type of componenet to create
-	 * \param[in] const int entityID The ID of the entity this component belongs to.
-	 * \param[in] std::vector<Property> &properties A vector containing the properties to apply to the created component.
-	 * \returns   IComponent* The newly create component
-	 */
-	void Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
-
 	/**
 	 * \brief Causes an update in the system based on the change in time.
 	 *
@@ -89,6 +76,12 @@ public:
 	 */
 	void SetViewportSize(const unsigned int width, const unsigned int height);
 
+    std::map<std::string,FactoryFunction> getFactoryFunctions();
+
+	void createGLSprite(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
+	void createGLIcoSphere(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
+	void createGLCubeSphere(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
+	void createGLMesh(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
 
 	IGLView* View() const { return view; }
 private:

--- a/src/systems/SImplePhysics.cpp
+++ b/src/systems/SImplePhysics.cpp
@@ -8,32 +8,29 @@ std::map<std::string,IFactory::FactoryFunction> SimplePhysics::getFactoryFunctio
     using namespace std::placeholders;
     std::map<std::string,IFactory::FactoryFunction> retval=
     {
-        {"PhysicsMover",std::bind(&SimplePhysics::Factory,this,_1,_2,_3)},
-        {"ViewMover",std::bind(&SimplePhysics::Factory,this,_1,_2,_3)}
+        {"PhysicsMover",std::bind(&SimplePhysics::createPhysicsMover,this,_1,_2,_3)},
+        {"ViewMover",std::bind(&SimplePhysics::createViewMover,this,_1,_2,_3)}
     };
     return retval;
 }
 
-IMoverComponent* SimplePhysics::Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
-	if (type == "PhysicsMover") {
+void SimplePhysics::createPhysicsMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
 		PhysicsMover* mover = new PhysicsMover(entityID);
 
-		for (auto propitr = properties.begin(); propitr != properties.end(); ++propitr) {
-			Property*  p = &(*propitr);
-			if (p->GetName() == "transform") {
-				GLTransform* t = p->Get<GLTransform*>();
-				mover->Transform(t);
-			}
-		}
-		this->components[entityID].push_back(mover);
-		return mover;
+    for (auto propitr = properties.begin(); propitr != properties.end(); ++propitr) {
+        Property*  p = &(*propitr);
+        if (p->GetName() == "transform") {
+            GLTransform* t = p->Get<GLTransform*>();
+            mover->Transform(t);
+        }
 	}
-	else if (type == "ViewMover") {
-		ViewMover* mover = new ViewMover(entityID);
-		this->components[entityID].push_back(mover);
-		return mover;
-	}
-	return nullptr;
+    this->components[entityID].push_back(mover);
+}
+
+void SimplePhysics::createViewMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties)
+{
+	ViewMover* mover = new ViewMover(entityID);
+    this->components[entityID].push_back(mover);
 }
 
 bool SimplePhysics::Update(const double delta) {

--- a/src/systems/SImplePhysics.cpp
+++ b/src/systems/SImplePhysics.cpp
@@ -3,6 +3,17 @@
 #include "../components/PhysicsMover.h"
 #include "../components/ViewMover.h"
 
+std::map<std::string,IFactory::FactoryFunction> SimplePhysics::getFactoryFunctions()
+{
+    using namespace std::placeholders;
+    std::map<std::string,IFactory::FactoryFunction> retval=
+    {
+        {"PhysicsMover",std::bind(&SimplePhysics::Factory,this,_1,_2,_3)},
+        {"ViewMover",std::bind(&SimplePhysics::Factory,this,_1,_2,_3)}
+    };
+    return retval;
+}
+
 IMoverComponent* SimplePhysics::Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
 	if (type == "PhysicsMover") {
 		PhysicsMover* mover = new PhysicsMover(entityID);

--- a/src/systems/SimplePhysics.h
+++ b/src/systems/SimplePhysics.h
@@ -21,18 +21,6 @@ public:
 	 */
 	bool Start() { }
 
-    std::map<std::string,FactoryFunction> getFactoryFunctions();
-	/**
-	 * \brief A factory to create new components of a given type.
-	 *
-	 * A factory method to create various components and add them to the system. These components will be used during the system update method
-	 * \param[in] const std::string type The type of componenet to create
-	 * \param[in] const int entityID The ID of the entity this component belongs to.
-	 * \param[in] std::vector<Property> &properties A vector containing the properties to apply to the created component.
-	 * \returns   void* The newly create component
-	 */
-	IMoverComponent* Factory(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
-
 	/**
 	 * \brief Causes an update in the system based on the change in time.
 	 *
@@ -49,6 +37,10 @@ public:
 	 * \returns   void* The component that belongs to the entity ID or nullptr if no component exists for the given ID.
 	 */
 	void* GetComponent(int entityID);
+
+    std::map<std::string,FactoryFunction> getFactoryFunctions();
+	void createPhysicsMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
+	void createViewMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
 private:
 	std::map<int, std::vector<IMoverComponent*> > components; // A mapping of entity ID to a vector containing all of it's components.
 };

--- a/src/systems/SimplePhysics.h
+++ b/src/systems/SimplePhysics.h
@@ -1,5 +1,7 @@
 #pragma  once
 
+#include "../IFactory.h"
+
 #include <string>
 #include <vector>
 #include <map>
@@ -7,7 +9,8 @@
 class Property;
 class IMoverComponent;
 
-class SimplePhysics {
+class SimplePhysics
+    : public IFactory  {
 public:
 	SimplePhysics() { }
 	~SimplePhysics();
@@ -18,6 +21,7 @@ public:
 	 */
 	bool Start() { }
 
+    std::map<std::string,FactoryFunction> getFactoryFunctions();
 	/**
 	 * \brief A factory to create new components of a given type.
 	 *
@@ -40,7 +44,7 @@ public:
 
 	/**
 	 * \brief Retrieve the component that belongs to the given entity ID
-	 * 
+	 *
 	 * \param[in] int entityID
 	 * \returns   void* The component that belongs to the entity ID or nullptr if no component exists for the given ID.
 	 */


### PR DESCRIPTION
Implements a basic FactorySystem, Factories(every class that has inherited from IFactory) can be registered with this FactorySystem so it can be used to create the Components it specified with the getFactoryFunctions()-method.

Current Examples are SimplePhysics and OpenGLSystem.
