### PR TITLE
ISystem implementation

### DIFF
--- a/src/IComponent.h
+++ b/src/IComponent.h
@@ -1,10 +1,17 @@
 #pragma once
+#include <string>
+
+#define SET_COMPONENT_ID(ID)                                \
+static const ComponentID getStaticComponentID() {return ID;}\
+virtual const ComponentID getComponentID() override{return getStaticComponentID();}
 
 class IComponent {
 public:
+    typedef std::string ComponentID;
 	IComponent(const int id = 0) : entityID(id) {}
 	virtual ~IComponent() {}
 	int GetEntityID() { return this->entityID; }
+	virtual const ComponentID getComponentID()=0;
 private:
 	const int entityID; // The entity that owns this component.
 };

--- a/src/ISystem.h
+++ b/src/ISystem.h
@@ -16,9 +16,19 @@ class ISystem
     public:
         ISystem() {};
         virtual ~ISystem() {};
+        /**
+         * \brief Retrieves a component
+         *
+         * Retrieves the Component specified by ID belonging to the Entity specified by EntityID
+         * In case t
+         * \param[in] std::size_t EntityId the Id of the Entity the wanted Component belongs to
+         * \param[in] IComponent::ComponentID ID The Id of the wanted Component
+         * \returns   T* returns the Component or NULL, if either the Entity doesn't exist or the Entity doesn't have that Component
+         */
         T* getComponent(std::size_t EntityID, IComponent::ComponentID ID)
         {
-            if(this->_Components.find(EntityID)!=this->_Components.end())
+            if(this->_Components.find(EntityID)!=this->_Components.end()&&
+               this->_Components[EntityID].find(ID)!=this->_Components[EntityID].end())
             {
                 return _Components[EntityID][ID].get();
             }else
@@ -26,6 +36,14 @@ class ISystem
                 return NULL;
             }
         }
+
+        /**
+         * \brief Adds a component
+         *
+         * Adds the given Component to the Entity specified by EntityID
+         * \param[in] std::size_t EntityId the Id of the Entity the Component belongs to
+         * \param[in] T* Component The Component that should be added to the given EntityID
+         */
         void addComponent(std::size_t EntityID,T* Component)
         {
             auto found=_Components.find(EntityID);

--- a/src/ISystem.h
+++ b/src/ISystem.h
@@ -1,0 +1,43 @@
+#ifndef ISYSTEM_H
+#define ISYSTEM_H
+
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <iostream>
+#include "IComponent.h"
+
+template<typename T>
+class ISystem
+{
+    typedef std::unordered_map< IComponent::ComponentID,
+                                std::unique_ptr<T>> ComponentMap;
+    typedef std::unordered_map<std::size_t,ComponentMap> EntityComponentMap;
+    public:
+        ISystem() {};
+        virtual ~ISystem() {};
+        T* getComponent(std::size_t EntityID, IComponent::ComponentID ID)
+        {
+            if(this->_Components.find(EntityID)!=this->_Components.end())
+            {
+                return _Components[EntityID][ID].get();
+            }else
+            {
+                return NULL;
+            }
+        }
+        void addComponent(std::size_t EntityID,T* Component)
+        {
+            auto found=_Components.find(EntityID);
+            if(found==_Components.end())
+            {
+                _Components.insert(std::pair<std::size_t,ComponentMap>(EntityID,ComponentMap()));
+            }
+            _Components[EntityID][Component->getComponentID()]=std::unique_ptr<T>(Component);
+        }
+    protected:
+        EntityComponentMap _Components;
+    private:
+};
+
+#endif // ISYSTEM_H

--- a/src/components/GLCubeSphere.h
+++ b/src/components/GLCubeSphere.h
@@ -8,6 +8,7 @@
 
 class GLCubeSphere : public IGLComponent {
 public:
+    SET_COMPONENT_ID("GLCubeSphere");
 	// We have a private ctor so the factory method must be used.
 	GLCubeSphere(const int entityID = 0);
 	virtual ~GLCubeSphere();
@@ -20,7 +21,7 @@ public:
 	 * \returns   void
 	 */
 	virtual void InitializeBuffers();
-	
+
 	/**
 	 * \brief Updates the rotation and renders the mesh
 	 *
@@ -39,7 +40,7 @@ public:
 	 * \params[in] Group - the index of the mesh group to count
 	 * \returns unsigned int The number of elements to draw.
 	 */
-	virtual unsigned int MeshGroup_ElementCount(const unsigned int group = 0) const { 
+	virtual unsigned int MeshGroup_ElementCount(const unsigned int group = 0) const {
 		if (group > 0) {
 			return 0;
 		}

--- a/src/components/GLIcoSphere.h
+++ b/src/components/GLIcoSphere.h
@@ -12,6 +12,7 @@ struct IcoScphereFace {
 
 class GLIcoSphere : public GLMesh {
 public:
+    SET_COMPONENT_ID("GLIcoSphere");
 	// We have a private ctor so the factory method must be used.
 	GLIcoSphere(const int entityID = 0);
 	/**
@@ -32,8 +33,8 @@ public:
 	 * \param[in/out] std::vector<Vertex> & verts The verts that will be used as a starting point. Any new verts created will be added to this.
 	 * \param[in/out] std::vector<Face> & faces The faces to refine. The set of faces will be stored here when complete.
 	 * \param[in] int level The number of refinements to apply.
-	 * \returns   void 
-	 * \exception  
+	 * \returns   void
+	 * \exception
 	 */
 	void Refine(std::vector<Sigma::Vertex> &verts, std::vector<Sigma::Face> &faces, int level);
 

--- a/src/components/GLMesh.h
+++ b/src/components/GLMesh.h
@@ -31,6 +31,7 @@ struct material {
 
 class GLMesh : public IGLComponent {
 public:
+    SET_COMPONENT_ID("GLMesh");
 	GLMesh(const int entityID); // Ctor that sets the entity ID.
 	/**
 	 * \brief Creates a new IGLComponent.
@@ -65,7 +66,7 @@ public:
 
 	/**
 	 * \brief Add a vertex to the list.
-	 * 
+	 *
 	 * \param[in] const Sigma::Vertex & v The vertex to add. It is copied.
 	 */
 	void AddVertex(const Sigma::Vertex& v) {
@@ -89,13 +90,13 @@ public:
 
 	/**
 	 * \brief Add a face to the list.
-	 * 
+	 *
 	 * \param[in] const Sigma::Face & f The face to add. It is copied.
 	 */
 	void AddFace(const Sigma::Face& f) {
 		this->faces.push_back(f);
 	}
-		
+
 	/**
 	 * \brief Gets a face.
 	 *
@@ -137,7 +138,7 @@ public:
 
 	/**
 	 * \brief Add a vertex normal to the list.
-	 * 
+	 *
 	 * \param[in] const Sigma::Vertex & v The vertex normal to add. It is copied.
 	 */
 	void AddVertexNormal(const Sigma::Vertex& vn) {
@@ -146,7 +147,7 @@ public:
 
 	/**
 	 * \brief Add a vertex color to the list.
-	 * 
+	 *
 	 * \param[in] const Sigma::Vertex & v The vertex color to add. It is copied.
 	 */
 	void AddVertexColor(const Sigma::Color& c) {

--- a/src/components/GLSprite.h
+++ b/src/components/GLSprite.h
@@ -5,6 +5,7 @@
 
 class GLSprite : public IGLComponent {
 public:
+    SET_COMPONENT_ID("GLSprite");
 	// We have a private ctor so the factory method must be used.
 	GLSprite(const int entityID = 0);
 	/**

--- a/src/components/PhysicsMover.h
+++ b/src/components/PhysicsMover.h
@@ -5,6 +5,7 @@ class GLTransform;
 
 class PhysicsMover : public IMoverComponent {
 public:
+    SET_COMPONENT_ID("PhysicsMover");
 	PhysicsMover() : IMoverComponent(0) { }
 	PhysicsMover(const int entityID);
 
@@ -19,7 +20,7 @@ public:
 	/**
 	 * \brief Sets the transform this mover acts on.
 	 *
-	 * 
+	 *
 	 * \param[in] GLTransform * transform The pointer to the transform to manipulate.
 	 */
 	void Transform(GLTransform* transform) {

--- a/src/components/ViewMover.h
+++ b/src/components/ViewMover.h
@@ -7,9 +7,10 @@ struct IGLView;
 
 class ViewMover : public IMoverComponent {
 public:
+    SET_COMPONENT_ID("ViewMover");
 	ViewMover() : IMoverComponent(0) { }
 	ViewMover(const int entityID);
-	
+
 	/**
 	 * \brief Apply all forces in this mover's list.
 	 *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,6 @@ int main(int argCount, char **argValues) {
 	}
 
 	Sigma::parser::SCParser parser;
-
 	parser.Parse("test.sc");
 
 	for (unsigned int i = 0; i < parser.EntityCount(); ++i) {
@@ -51,8 +50,7 @@ int main(int argCount, char **argValues) {
 
 	std::vector<Property> props;
 	physys.createViewMover("ViewMover", 9, props);
-	ViewMover* mover = reinterpret_cast<ViewMover*>(physys.GetComponent(9));
-
+	ViewMover* mover = reinterpret_cast<ViewMover*>(physys.getComponent(9,ViewMover::getStaticComponentID()));
 	Sigma::event::handler::GLSixDOFViewController cameraController(glsys.View(), mover);
 	IOpSys::KeyboardEventSystem.Register(&cameraController);
 

--- a/src/systems/OpenGLSystem.cpp
+++ b/src/systems/OpenGLSystem.cpp
@@ -12,11 +12,6 @@ OpenGLSystem::OpenGLSystem() : windowWidth(800), windowHeight(600), deltaAccumul
 
 OpenGLSystem::~OpenGLSystem() {
 	delete this->view;
-	for (auto eitr = this->components.begin(); eitr != this->components.end(); ++eitr) {
-		for (auto citr = eitr->second.begin(); citr != eitr->second.end(); ++citr) {
-			delete citr->second;
-		}
-	}
 }
 
 std::map<std::string,IFactory::FactoryFunction>
@@ -39,8 +34,8 @@ void OpenGLSystem::createGLSprite(const std::string type, const unsigned int ent
 		if (entityID == 2) {
 			spr->Transform()->Translate(2,2,0);
 		}
-		this->components[entityID][0] = spr;
 		spr->Transform()->Translate(0,0,0);
+		this->addComponent(entityID,spr);
 }
 
 void OpenGLSystem::createGLIcoSphere(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
@@ -71,7 +66,7 @@ void OpenGLSystem::createGLIcoSphere(const std::string type, const unsigned int 
 		}
 		sphere->Transform()->Scale(scale,scale,scale);
 		sphere->Transform()->Translate(x,y,z);
-		this->components[entityID][componentID] = sphere;
+		this->addComponent(entityID,sphere);
 }
 
 void OpenGLSystem::createGLCubeSphere(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
@@ -102,7 +97,7 @@ void OpenGLSystem::createGLCubeSphere(const std::string type, const unsigned int
 		}
 		sphere->Transform()->Scale(scale,scale,scale);
 		sphere->Transform()->Translate(x,y,z);
-		this->components[entityID][componentID] = sphere;
+		this->addComponent(entityID,sphere);
 }
 void OpenGLSystem::createGLMesh(const std::string type, const unsigned int entityID, std::vector<Property> &properties) {
         GLMesh* mesh = new GLMesh(entityID);
@@ -134,7 +129,7 @@ void OpenGLSystem::createGLMesh(const std::string type, const unsigned int entit
 		mesh->InitializeBuffers();
 		mesh->Transform()->Scale(scale,scale,scale);
 		mesh->Transform()->Translate(x,y,z);
-		this->components[entityID][componentID] = mesh;
+		this->addComponent(entityID,mesh);
 }
 
 bool OpenGLSystem::Update(const double delta) {
@@ -149,7 +144,7 @@ bool OpenGLSystem::Update(const double delta) {
 
 		// Set the ViewProjection matrix to be used in the shader.
 		// Loop through and draw each component.
-		for (auto eitr = this->components.begin(); eitr != this->components.end(); ++eitr) {
+		for (auto eitr = this->_Components.begin(); eitr != this->_Components.end(); ++eitr) {
 			for (auto citr = eitr->second.begin(); citr != eitr->second.end(); ++citr) {
 				citr->second->Update(&this->view->ViewMatrix[0][0], &this->ProjectionMatrix[0][0]);
 			}
@@ -159,15 +154,6 @@ bool OpenGLSystem::Update(const double delta) {
 		return true;
 	}
 	return false;
-}
-
-IGLComponent* OpenGLSystem::GetComponent(const unsigned int entityID, const unsigned int componentID) {
-	if (this->components.find(entityID) != this->components.end()) {
-		if (this->components.at(entityID).find(componentID) != this->components.at(entityID).end()) {
-			return this->components[entityID][componentID];
-		}
-	}
-	return nullptr;
 }
 
 const int* OpenGLSystem::Start() {

--- a/src/systems/OpenGLSystem.h
+++ b/src/systems/OpenGLSystem.h
@@ -2,6 +2,7 @@
 
 #include "../Property.h"
 #include "../IFactory.h"
+#include "../ISystem.h"
 
 #include "GL/glew.h"
 #include "glm/glm.hpp"
@@ -11,7 +12,7 @@ struct IGLView;
 class IGLComponent;
 
 class OpenGLSystem
-    : public IFactory {
+    : public IFactory, public ISystem<IGLComponent> {
 public:
 	OpenGLSystem();
 
@@ -36,15 +37,6 @@ public:
 	 * \returns bool Returns true if we had an update interval passed.
 	 */
 	bool Update(const double delta);
-
-	/**
-	 * \brief Retrieve the component that belongs to the given entity ID
-	 *
-	 * \param[in] const unsigned int entityID
-	 * \param[in] const unsigned int componentID
-	 * \returns   IComponent* The component that belongs to the entity ID or nullptr if no component exists for the given ID.
-	 */
-	IGLComponent* GetComponent(const unsigned int entityID, const unsigned int componentID);
 
 	/**
 	 * \brief Move the camera around the world.
@@ -95,5 +87,4 @@ private:
 	glm::mat4 ProjectionMatrix;
 	IGLView* view;
 	double deltaAccumulator;
-	std::map<int, std::map<int, IGLComponent*> > components; // A mapping of entity ID to a mapping of component ID to component.
 };

--- a/src/systems/SimplePhysics.cpp
+++ b/src/systems/SimplePhysics.cpp
@@ -24,42 +24,27 @@ void SimplePhysics::createPhysicsMover(const std::string type, const unsigned in
             mover->Transform(t);
         }
 	}
-    this->components[entityID].push_back(mover);
+	this->addComponent(entityID,mover);
 }
 
 void SimplePhysics::createViewMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties)
 {
 	ViewMover* mover = new ViewMover(entityID);
-    this->components[entityID].push_back(mover);
+	this->addComponent(entityID,mover);
 }
 
 bool SimplePhysics::Update(const double delta) {
 	// Move
-	for (auto eitr = this->components.begin(); eitr != this->components.end(); ++eitr) {
+	for (auto eitr = this->_Components.begin(); eitr != this->_Components.end(); ++eitr) {
 		for (auto citr = eitr->second.begin(); citr != eitr->second.end(); ++citr) {
-			(*citr)->ApplyForces(delta);
+			citr->second->ApplyForces(delta);
 		}
 	}
 
 	// Check for collisions and set position to contact point
-	for (auto itr = this->components.begin(); itr != this->components.end(); ++itr) {
+	for (auto itr = this->_Components.begin(); itr != this->_Components.end(); ++itr) {
 
 	}
 
 	return true;
-}
-
-void* SimplePhysics::GetComponent(int entityID) {
-	if (this->components.find(entityID) != this->components.end()) {
-		return this->components[entityID][0];
-	}
-	return nullptr;
-}
-
-SimplePhysics::~SimplePhysics() {
-	for (auto eitr = this->components.begin(); eitr != this->components.end(); ++eitr) {
-		for (auto citr = eitr->second.begin(); citr != eitr->second.end(); ++citr) {
-			delete (*citr);
-		}
-	}
 }

--- a/src/systems/SimplePhysics.h
+++ b/src/systems/SimplePhysics.h
@@ -1,6 +1,7 @@
 #pragma  once
 
 #include "../IFactory.h"
+#include "../ISystem.h"
 
 #include <string>
 #include <vector>
@@ -10,10 +11,10 @@ class Property;
 class IMoverComponent;
 
 class SimplePhysics
-    : public IFactory  {
+    : public IFactory, public ISystem<IMoverComponent> {
 public:
 	SimplePhysics() { }
-	~SimplePhysics();
+	~SimplePhysics() { };
 	/**
 	 * \brief Starts the Simple Physics system.
 	 *
@@ -30,17 +31,8 @@ public:
 	 */
 	bool Update(const double delta);
 
-	/**
-	 * \brief Retrieve the component that belongs to the given entity ID
-	 *
-	 * \param[in] int entityID
-	 * \returns   void* The component that belongs to the entity ID or nullptr if no component exists for the given ID.
-	 */
-	void* GetComponent(int entityID);
-
     std::map<std::string,FactoryFunction> getFactoryFunctions();
 	void createPhysicsMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
 	void createViewMover(const std::string type, const unsigned int entityID, std::vector<Property> &properties) ;
 private:
-	std::map<int, std::vector<IMoverComponent*> > components; // A mapping of entity ID to a vector containing all of it's components.
 };


### PR DESCRIPTION
This implements a basics ISystem, in its current state it is simply a way to handle the Components one system contains without having to reimplement it in every System. Furthermore there are some changes to IComponent adding a ComponentID to this class. Currently the ComponentID is a string, thought it could be changed into hash-function calulated at compile-time later on by changing SET_COMPONENT_ID(ID).

Since there is no PM function I will just write this here:
I am thinking of expanding the ISystem and the concept behind it a bit further, though the changes required are rather drastic, therefore I wanted to ask beforehand if they are fitting into the general design you want to follow with Sigma or not.
Basically I am thinking of cutting out the Update and ApplyForces Functions and putting that logic either into the Systems itself or into Subsystems, those would basically just be methods, that take 1 or more Components of a given Entity and manipulate them based on what they try to accomplish. Furthermore it would remove the need of the System itself to know the type of Component it is handling outside of the actual logic which would allow to make ISystem into a non-template class. The major point of that is, that it would make it easier/possible to create a central SystemManager/ComponentManger or something similiar, the function would be comparable to the Current FactorySystem in that Systems would register with it and supply a list of Components they are responsible for. That way (Sub)Systems would be able to retrieve and manipulate Components via this ComponentManager that are not their direct responsibility but still need to be manipulated by them. One example for this necessity that comes to mind would be a Position Component, which would be needed by both the Physics and the Rendering System, it could now be added to either of them, while allowing the other System to retrieve it whenever needed.
