### PR TITLE
Switched to markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,29 @@ GUI Mode
 Command Mode
 ---
 
-* mkdir build/
-* cd build/
-* cmake ..
-* make
+```sh
+mkdir build/
+cd build/
+cmake ..
+make
+```
 
 
 Using the makefile-wrapper
 ---
 
-* make rebuild # make clean; make
+```sh
+make rebuild
+make clean
+make
+```
 
 Eclipse CDT (Unix/Linux)
 ---
 
-* make eclipse
+```sh
+make eclipse
+```
 
 After compiling
 ---


### PR DESCRIPTION
If you don't want this because of plain text readability, there is always the option of simple indentation which does essentially the same thing, bar syntax highlighting.
