### PR TITLE
Added Travis-CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+language: cpp
+compiler: gcc
+before_install:
+    # libstdc++-4.8-dev
+    - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+    # clang++-3.2 and gcc 4.8
+    - sudo add-apt-repository --yes ppa:h-rayflood/llvm
+    # libsdl2
+    - sudo add-apt-repository --yes ppa:zoogie/sdl2-snapshots
+    # Playdeb has a repo that provides bullet. However their site has issues today and I was unable to use it
+    # This would provide bullet without needing to compile by hand
+    #- wget -q -O - http://archive.getdeb.net/getdeb-archive.key | sudo apt-key add -
+    #- sudo sh -c 'echo "deb http://archive.getdeb.net/ubuntu precise-getdeb games" >> /etc/apt/sources.list.d/getdeb.list'
+    #- wget http://archive.getdeb.net/install_deb/getdeb-repository_0.1-1~getdeb1_all.deb
+    #- sudo dpkg -i getdeb-repository_0.1-1~getdeb1_all.deb
+    - sudo apt-get -qq update
+install:
+    - sudo apt-get -qq install libstdc++-4.8-dev clang-3.3 libsdl2
+    - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    - sudo apt-get -qq install libglew-dev libsoil-dev libglm-dev libsdl2-dev
+    - sudo apt-get install libgtest-dev
+    - BUILD_PATH = $(pwd)
+    - cd /usr/src/gtest
+    - sudo cmake CMakeLists.txt
+    - sudo make
+    - sudo cp *.a /usr/lib
+    # Hardcoded for now until we get to a better system
+    #- cd /home/travis/build/croxis/Sigma
+    - cd $BUILD_PATH
+    # Temporary to manually build bullet
+    - sudo apt-get -y install automake libtool cmake freeglut3-dev subversion
+    - svn checkout http://bullet.googlecode.com/svn/trunk/ bullet-read-only
+    - cd bullet-read-only
+    - cmake . -G "Unix Makefiles" -DBUILD_SHARED_LIBS=ON
+    - make -j10 && sudo make install
+    - cd ..
+script:
+    - cp test.sc.complex test.sc
+    - "sudo ln -s /usr/include/SOIL/SOIL.h /usr/include/SOIL.h"
+    #- make rebuild
+    - make clean
+    - make
+notifications:
+    email: false
+    # I can also set up Glitch to output build results as well if we don't want the travis bot join/part spam
+    irc:
+        - "chat.freenode.net#sigma-gcf"
+        - "chat.freenode.net#project-trillek"


### PR DESCRIPTION
This requires a travis-ci account and then linking it to the proper github repo. This system can be expanded to later do unit tests and maybe upload successful builds to a remote server.
