### PR TITLE
GUI transparency and mouse events

### DIFF
--- a/include/IBulletShape.h
+++ b/include/IBulletShape.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "bullet/btBulletCollisionCommon.h"
-#include "bullet/btBulletDynamicsCommon.h"
+#include <bullet/btBulletCollisionCommon.h>
+#include <bullet/btBulletDynamicsCommon.h>
 #include "IComponent.h"
 
 

--- a/include/components/GLScreenQuad.h
+++ b/include/components/GLScreenQuad.h
@@ -34,7 +34,7 @@ public:
 
 		while(dim < width && dim < height) {
 			power += 1;
-			dim = (int)pow(2, power);
+			dim = 1 << power;
 		}
 
 		return dim;

--- a/include/components/WebGUIComponent.h
+++ b/include/components/WebGUIComponent.h
@@ -14,8 +14,8 @@ namespace Sigma {
 	class WebGUIView : public Sigma::IComponent {
 	public:
 		SET_COMPONENT_TYPENAME("WebGUIView");
-		WebGUIView() : IComponent(0), texture(nullptr) { }
-		WebGUIView(const int entityID) : IComponent(entityID), texture(nullptr) { };
+		WebGUIView() : IComponent(0), texture(nullptr), mouseDown(0) { }
+		WebGUIView(const int entityID) : IComponent(entityID), texture(nullptr), mouseDown(0) { };
 
 		void SetTexture(Sigma::resource::GLTexture* texture) {
 			this->texture = texture;
@@ -59,13 +59,16 @@ namespace Sigma {
 
 		void InjectCharDown(const unsigned int c);
 
-		void InjectMouseDown(const Sigma::event::BUTTON btn, float x, float y);
+		bool InjectMouseMove(float x, float y);
+		bool InjectMouseDown(const Sigma::event::BUTTON btn, float x, float y);
+		bool InjectMouseUp(const Sigma::event::BUTTON btn, float x, float y);
 	private:
 		WebView* view;
 		BitmapSurface* surface;
 		Sigma::resource::GLTexture* texture;
 
 		bool hasFocus;
+		unsigned int mouseDown;
 
 		float x, y, width, height; // The region in which to capture mouse inputs.
 		unsigned int windowWidth; // The width of the window

--- a/include/controllers/FPSCamera.h
+++ b/include/controllers/FPSCamera.h
@@ -34,7 +34,7 @@ namespace Sigma {
 				 * \param[in/out] float dx, dy The change in mouse position.
 				 * \param[in/out] float dy
 				 */
-				virtual void MouseMove(float dx, float dy);
+				virtual void MouseMove(float x, float y, float dx, float dy);
 
 				// Not used but required to implement.
 				virtual void MouseDown(Sigma::event::BUTTON btn, float x, float y) {}

--- a/include/controllers/GUIController.h
+++ b/include/controllers/GUIController.h
@@ -35,11 +35,11 @@ namespace Sigma {
 				 * \param[in/out] float dx, dy The change in mouse position.
 				 * \param[in/out] float dy
 				 */
-				virtual void MouseMove(float dx, float dy) { }
+				virtual void MouseMove(float x, float y, float dx, float dy);
 
 				// Not used but required to implement.
 				virtual void MouseDown(Sigma::event::BUTTON btn, float x, float y);
-				virtual void MouseUp(Sigma::event::BUTTON btn, float x, float y) { }
+				virtual void MouseUp(Sigma::event::BUTTON btn, float x, float y);
 			private:
 				WebGUIView* gui;
 				bool hasFocus;

--- a/include/systems/MouseInputSystem.h
+++ b/include/systems/MouseInputSystem.h
@@ -14,7 +14,7 @@ namespace Sigma{
         struct IMouseEventHandler{
             float mouse_x, mouse_y; // current pixel locations
             BUTTON_STATE buttons[3]; // left, middle, right
-            virtual void MouseMove(float dx, float dy) = 0; // given displacement since last call
+            virtual void MouseMove(float x, float y, float dx, float dy) = 0; // given displacement since last call
 			virtual void MouseDown(BUTTON btn, float x, float y) = 0; // called on button press.
             virtual void MouseUp(BUTTON btn, float x, float y) = 0;
         };
@@ -39,9 +39,9 @@ namespace Sigma{
 				 *
 				 * Loops through each event handler that is registered and passes mouse movement information.
 				 */
-				void MouseMove(float dx, float dy) {
+				void MouseMove(float x, float y, float dx, float dy) {
 					for (auto itr = this->eventHandlers.begin(); itr != this->eventHandlers.end(); ++itr) {
-						(*itr)->MouseMove(dx, dy);
+						(*itr)->MouseMove(x, y, dx, dy);
 					}
 				}
 

--- a/include/systems/WebGUISystem.h
+++ b/include/systems/WebGUISystem.h
@@ -19,7 +19,7 @@ using namespace Awesomium;
 namespace Sigma {
 	class WebGUISystem : public IFactory, public ISystem<WebGUIView> {
 	public:
-		WebGUISystem() { }
+		WebGUISystem() : web_core(nullptr) { }
 		~WebGUISystem() { };
 		/**
 		 * \brief Starts the Awesomium WebGUI system.

--- a/src/components/BulletMover.cpp
+++ b/src/components/BulletMover.cpp
@@ -1,7 +1,7 @@
 #include "components/BulletMover.h"
 
-#include "bullet/btBulletCollisionCommon.h"
-#include "bullet/btBulletDynamicsCommon.h"
+#include <bullet/btBulletCollisionCommon.h>
+#include <bullet/btBulletDynamicsCommon.h>
 
 namespace Sigma {
 

--- a/src/components/WebGUIComponent.cpp
+++ b/src/components/WebGUIComponent.cpp
@@ -27,19 +27,54 @@ namespace Sigma {
 		}
 	}
 
-	void WebGUIView::InjectMouseDown(const Sigma::event::BUTTON btn, float x, float y) {
+	bool WebGUIView::InjectMouseMove(float x, float y) {
+		if(this->mouseDown == 0) {
+			if ((x > this->x) && (x < (this->x + this->width))) {
+				if ((y > this->y) && (y < (this->y + this->height))) {
+					this->view->Focus();
+					this->hasFocus = true;
+					this->view->InjectMouseMove((x - this->x) * this->windowWidth, (y - this->y) * this->windowHeight);
+					return true;
+				}
+			}
+			this->view->Unfocus();
+			this->hasFocus = false;
+		}
+		else {
+			this->view->InjectMouseMove((x - this->x) * this->windowWidth, (y - this->y) * this->windowHeight);
+			return true;
+		}
+		return false;
+	}
+
+	bool WebGUIView::InjectMouseDown(const Sigma::event::BUTTON btn, float x, float y) {
+		if (btn != Sigma::event::BUTTON::LEFT) { return false; }
 		if ((x > this->x) && (x < (this->x + this->width))) {
 			if ((y > this->y) && (y < (this->y + this->height))) {
 				this->view->Focus();
 				this->hasFocus = true;
 				this->view->InjectMouseMove((x - this->x) * this->windowWidth, (y - this->y) * this->windowHeight);
 				this->view->InjectMouseDown(kMouseButton_Left);
-				this->view->InjectMouseUp(kMouseButton_Left);
-				return; // Early return to prevent foxus loss.
+				this->mouseDown = 1;
+				//this->view->InjectMouseUp(kMouseButton_Left);
+				return true; // Early return to prevent focus loss.
 			}
 		}
 		this->view->Unfocus();
 		this->hasFocus = false;
+		return false;
+	}
+
+	bool WebGUIView::InjectMouseUp(const Sigma::event::BUTTON btn, float x, float y) {
+		if (this->hasFocus) {
+			this->view->InjectMouseMove((x - this->x) * this->windowWidth, (y - this->y) * this->windowHeight);
+			this->view->InjectMouseUp(kMouseButton_Left);
+			this->mouseDown = 0;
+			return true;
+		}
+		this->view->Unfocus();
+		this->hasFocus = false;
+		return false;
 	}
 
 	void WebGUIView::InjectCharDown(const unsigned int c) {

--- a/src/controllers/FPSCamera.cpp
+++ b/src/controllers/FPSCamera.cpp
@@ -52,7 +52,7 @@ namespace Sigma{
 
 			} // function KeyStateChange
 
-			void FPSCamera::MouseMove(float dx, float dy) {
+			void FPSCamera::MouseMove(float x, float y, float dx, float dy) {
 				if (this->mover) {
 					this->mover->RotateTarget(dy,dx,0.0f);
 				}

--- a/src/controllers/GUIController.cpp
+++ b/src/controllers/GUIController.cpp
@@ -31,6 +31,20 @@ namespace Sigma {
 					this->gui->InjectMouseDown(btn, x, y);
 				}
 			}
+
+			void GUIController::MouseUp(Sigma::event::BUTTON btn, float x, float y) {
+				// Store the new key state
+				if (this->gui) {
+					this->gui->InjectMouseUp(btn, x, y);
+				}
+			}
+
+			void GUIController::MouseMove(float x, float y, float dx, float dy) {
+				// Store the new key state
+				if (this->gui) {
+					this->gui->InjectMouseMove(x, y);
+				}
+			}
 		}
 	}
 }

--- a/src/os/sdl/SDLSys.cpp
+++ b/src/os/sdl/SDLSys.cpp
@@ -122,7 +122,10 @@ bool SDLSys::MessageLoop() {
             }
 
             // Dispatch the event
-            MouseEventSystem.MouseMove(dx, dy);
+            MouseEventSystem.MouseMove(
+				static_cast<float>(event.motion.x) / static_cast<float>(this->GetWindowWidth()),
+				static_cast<float>(event.motion.y) / static_cast<float>(this->GetWindowHeight()),
+				dx, dy);
 
             // if mouse is hidden/grabbed and moved, recenter it so it doesn't appear offscreen
             SDL_EventState(SDL_MOUSEMOTION, SDL_IGNORE);

--- a/src/os/win32/win32.cpp
+++ b/src/os/win32/win32.cpp
@@ -114,19 +114,26 @@ LRESULT CALLBACK win32::WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM l
 		if (mouselook) {
 			mouseMoved = true;
 			if ((abs(GET_X_LPARAM(lParam) - midwindow.x) > 2) && (abs(GET_Y_LPARAM(lParam) - midwindow.y) > 2)) {
-				MouseEventSystem.MouseMove((GET_X_LPARAM(lParam) - midwindow.x) / static_cast<float>(windowHeight) * 500.0f, (GET_Y_LPARAM(lParam) - midwindow.y) / static_cast<float>(windowWidth) * 500.0f);
+				MouseEventSystem.MouseMove(static_cast<float>(GET_X_LPARAM(lParam)) / static_cast<float>(windowWidth), static_cast<float>(GET_Y_LPARAM(lParam)) / static_cast<float>(windowHeight), (GET_X_LPARAM(lParam) - midwindow.x) / static_cast<float>(windowHeight) * 500.0f, (GET_Y_LPARAM(lParam) - midwindow.y) / static_cast<float>(windowWidth) * 500.0f);
 			}
 			else if (abs(GET_X_LPARAM(lParam) - midwindow.x) > 2) {
-				MouseEventSystem.MouseMove((GET_X_LPARAM(lParam) - midwindow.x) / static_cast<float>(windowHeight) * 500.0f, 0.0f);
+				MouseEventSystem.MouseMove(static_cast<float>(GET_X_LPARAM(lParam)) / static_cast<float>(windowWidth), static_cast<float>(GET_Y_LPARAM(lParam)) / static_cast<float>(windowHeight), (GET_X_LPARAM(lParam) - midwindow.x) / static_cast<float>(windowHeight) * 500.0f, 0.0f);
 			}
 			else if (abs(GET_Y_LPARAM(lParam) - midwindow.y) > 2) {
-				MouseEventSystem.MouseMove(0.0f, (GET_Y_LPARAM(lParam) - midwindow.y) / static_cast<float>(windowWidth) * 500.0f);
+				MouseEventSystem.MouseMove(static_cast<float>(GET_X_LPARAM(lParam)) / static_cast<float>(windowWidth), static_cast<float>(GET_Y_LPARAM(lParam)) / static_cast<float>(windowHeight), 0.0f, (GET_Y_LPARAM(lParam) - midwindow.y) / static_cast<float>(windowWidth) * 500.0f);
 			}
 			else {
 				mouseMoved = false;
 			}
 			ClientToScreen(hwnd, &midwindow);
 			SetCursorPos(midwindow.x, midwindow.y);
+		}
+		else {
+			mouseMoved = true;
+			MouseEventSystem.MouseMove(static_cast<float>(GET_X_LPARAM(lParam)) / static_cast<float>(windowWidth), static_cast<float>(GET_Y_LPARAM(lParam)) / static_cast<float>(windowHeight), 0.0f, 0.0f);
+		}
+		if (!mouseMoved) {
+			MouseEventSystem.MouseMove(0.f, 0.f, 0.f, 0.f);
 		}
 		break;
 	case WM_LBUTTONDOWN:
@@ -148,10 +155,6 @@ LRESULT CALLBACK win32::WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM l
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		break;
-	}
-
-	if (!mouseMoved) {
-		MouseEventSystem.MouseMove(0.f, 0.f);
 	}
 
 	return DefWindowProc(hwnd, message, wParam, lParam);

--- a/src/systems/OpenGLSystem.cpp
+++ b/src/systems/OpenGLSystem.cpp
@@ -612,6 +612,9 @@ namespace Sigma{
 				}
 			}
 
+			// Enable transparent rendering
+			glEnable(GL_BLEND);
+			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 			for (auto citr = this->screensSpaceComp.begin(); citr != this->screensSpaceComp.end(); ++citr) {
 					citr->get()->GetShader()->Use();
 
@@ -624,6 +627,8 @@ namespace Sigma{
 					glUniform1f(glGetUniformLocation(citr->get()->GetShader()->GetProgram(), "specularLightIntensity"), 0.0f);
 					citr->get()->Render(&viewMatrix[0][0], &this->ProjectionMatrix[0][0]);
 			}
+			// Remove blending
+			glDisable(GL_BLEND);
 
 			// Unbind frame buffer
 			glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/src/systems/WebGUISystem.cpp
+++ b/src/systems/WebGUISystem.cpp
@@ -39,6 +39,7 @@ namespace Sigma {
 
 	IComponent* WebGUISystem::createWebGUIView(const unsigned int entityID, const std::vector<Property> &properties) {
 		float x, y, width, height;
+		bool transparent = false;
 		std::string textureName = "";
 		WebURL url;
 
@@ -60,17 +61,21 @@ namespace Sigma {
 			else if (p->GetName() == "textureName") {
 				textureName = p->Get<std::string>();
 			}
+			else if (p->GetName() == "transparent") {
+				transparent = p->Get<bool>();
+			}
 			else if (p->GetName() == "URL") {
 				url = WebURL(WSLit(p->Get<std::string>().c_str()));
 			}
 		}
 		WebGUIView* webview = new WebGUIView(entityID);
 		WebView* view = web_core->CreateWebView(width * this->windowWidth, height * this->windowHeight);
-
+		
 		if (!url.IsValid()) {
 			std::cerr << "Invalid URL" << std::endl;
 		}
 		view->LoadURL(url);
+		view->SetTransparent(transparent);
 
 		while (view->IsLoading()) {
 			this->web_core->Update();


### PR DESCRIPTION
These changes add transparency option for GUI views, it makes screen quads render with alpha blend and adds on option to enable this transparency on WebViews (off by default)
The property for this is

```
&WebGUIView
>transparent=1b
```

This also makes mouseMove events take 4 parameters instead of the original 2, absolute position (normalized 0..1) and delta position (unchanged).
all mouse inject events return bool of status (clicked or not).
