### PR TITLE
Fix error in initialization of BulletMover and FPSCamera. issue #71

### DIFF
--- a/src/controllers/FPSCamera.cpp
+++ b/src/controllers/FPSCamera.cpp
@@ -70,7 +70,7 @@ namespace Sigma{
 			}
 
 			void FPSCamera::SetMover(BulletMover* m){
-				if (this->mover) {
+				if (m) {
 					m->SetTransform(this->Transform);
 					this->mover = m;
 				}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,6 +124,7 @@ int main(int argCount, char **argValues) {
 		IOpSys::KeyboardEventSystem.Register(theCamera);
 		IOpSys::MouseEventSystem.Register(theCamera);
 		theCamera->SetMover(mover);
+		mover->SetTransform(theCamera->Transform);
 	} else if (glsys.GetViewMode() == "GLSixDOFView") {
 		Sigma::event::handler::GLSixDOFViewController cameraController(glsys.GetView(), mover);
 		IOpSys::KeyboardEventSystem.Register(&cameraController);


### PR DESCRIPTION
Fix error causing a segfault in glm::vec3::vec3 constructor while initializing BulletMover.

Fix also a mistype that caused an uncomplete initialization of FPSCamera.
