### PR TITLE
Fix missing library when linking GLFW3

### DIFF
--- a/modules/FindGLFW3.cmake
+++ b/modules/FindGLFW3.cmake
@@ -32,9 +32,8 @@ ELSE(WIN32)
 		INCLUDE_DIRECTORIES( "${GLFW3_INCLUDE_PATH}" )
 	ENDIF(APPLE)
 
-	# Prefer the static library.
 	FIND_LIBRARY( GLFW3_LIBRARY
-        NAMES libGLFW.a GLFW libGLFW3.a GLFW3 libglfw.so libglfw.so.3 libglfw.so.3.0 glfw3
+        NAMES libglfw.so libglfw.so.3 libglfw.so.3.0 glfw3
 		PATHS
 		/usr/lib64
 		/usr/lib
@@ -44,8 +43,6 @@ ELSE(WIN32)
 		/opt/local/lib
 		${GLFW_ROOT_DIR}/lib
 		DOC "The GLFW library")
-		# Fix linker complaining about undefined references
-		SET(GLFW3_LIBRARY ${GLFW3_LIBRARY} Xxf86vm)
 ENDIF(WIN32)
 
 INCLUDE(FindPackageHandleStandardArgs)

--- a/modules/FindGLFW3.cmake
+++ b/modules/FindGLFW3.cmake
@@ -44,13 +44,12 @@ ELSE(WIN32)
 		/opt/local/lib
 		${GLFW_ROOT_DIR}/lib
 		DOC "The GLFW library")
+		# Fix linker complaining about undefined references
+		SET(GLFW3_LIBRARY ${GLFW3_LIBRARY} Xxf86vm)
 ENDIF(WIN32)
 
 INCLUDE(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GLFW3 DEFAULT_MESSAGE GLFW3_LIBRARY GLFW3_INCLUDE_PATH)
-
-# Fix linker complaining about undefined references
-SET(GLFW3_LIBRARY ${GLFW3_LIBRARY} Xxf86vm)
 
 #SET(GLFW3_FOUND "NO")
 #IF(GLFW3_INCLUDE_PATH AND GLFW3_LIBRARY)

--- a/modules/FindGLFW3.cmake
+++ b/modules/FindGLFW3.cmake
@@ -5,7 +5,7 @@
 # GLFW3_FOUND
 # GLFW3_INCLUDE_PATH
 # GLFW3_LIBRARY
-# 
+#
 
 IF(WIN32)
     FIND_PATH( GLFW3_INCLUDE_PATH GLFW/glfw3.h
@@ -48,6 +48,9 @@ ENDIF(WIN32)
 
 INCLUDE(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GLFW3 DEFAULT_MESSAGE GLFW3_LIBRARY GLFW3_INCLUDE_PATH)
+
+# Fix linker complaining about undefined references
+SET(GLFW3_LIBRARY ${GLFW3_LIBRARY} Xxf86vm)
 
 #SET(GLFW3_FOUND "NO")
 #IF(GLFW3_INCLUDE_PATH AND GLFW3_LIBRARY)


### PR DESCRIPTION
This may concern only gcc users. It should not bother other compilers.
