### PR TITLE
Fix local inconsitence across systems

### DIFF
--- a/src/SCParser.cpp
+++ b/src/SCParser.cpp
@@ -13,8 +13,6 @@ namespace Sigma {
      */
     struct SetLocals {
       SetLocals() {
-      
-        setlocale(LC_ALL|~LC_NUMERIC, "");
         setlocale(LC_NUMERIC, "C"); // We must parse numbers in a consistent way
       }
 

--- a/src/SCParser.cpp
+++ b/src/SCParser.cpp
@@ -8,6 +8,21 @@
 
 namespace Sigma {
 	namespace parser {
+    /**
+     * Change locals to "C" for numbers inside the code block were is created as uses RAII
+     */
+    struct SetLocals {
+      SetLocals() {
+      
+        setlocale(LC_ALL|~LC_NUMERIC, "");
+        setlocale(LC_NUMERIC, "C"); // We must parse numbers in a consistent way
+      }
+
+      ~SetLocals() {
+        setlocale(LC_ALL, ""); // Restores system local
+      }
+    };
+
 		bool SCParser::Parse(const std::string& fname) {	
       this->fname = fname;
 			std::ifstream in(this->fname, std::ios::in);
@@ -18,9 +33,8 @@ namespace Sigma {
 				return false;
 			}
 
-      setlocale(LC_ALL|~LC_NUMERIC, "");
-      setlocale(LC_NUMERIC, "C"); // We must parse numbers in a consistent way
-
+      auto locals = SetLocals();
+  
       std::string line;
 			Sigma::parser::Entity* currentEntity = nullptr;
 
@@ -94,7 +108,6 @@ namespace Sigma {
 				delete currentEntity; // delete the heap original
 			}
 
-      setlocale(LC_ALL, "");
 			return true; // Successfully parsed a file. It might have been empty though.
 		}
 

--- a/src/SCParser.cpp
+++ b/src/SCParser.cpp
@@ -4,11 +4,12 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <locale.h>
 
 namespace Sigma {
 	namespace parser {
-		bool SCParser::Parse(const std::string& fname) {
-			this->fname = fname;
+		bool SCParser::Parse(const std::string& fname) {	
+      this->fname = fname;
 			std::ifstream in(this->fname, std::ios::in);
 
 			// Some type of error opening the file
@@ -17,7 +18,10 @@ namespace Sigma {
 				return false;
 			}
 
-			std::string line;
+      setlocale(LC_ALL|~LC_NUMERIC, "");
+      setlocale(LC_NUMERIC, "C"); // We must parse numbers in a consistent way
+
+      std::string line;
 			Sigma::parser::Entity* currentEntity = nullptr;
 
 			while (getline(in, line)) {
@@ -89,6 +93,8 @@ namespace Sigma {
 				this->entities.push_back(*currentEntity); // copy
 				delete currentEntity; // delete the heap original
 			}
+
+      setlocale(LC_ALL, "");
 			return true; // Successfully parsed a file. It might have been empty though.
 		}
 


### PR DESCRIPTION
Fix the parsers to not use the local decimal separator, and instead enforces to use local C to parse numbers.

Need to check if works well in other systems, as I only tested in Linux.
