### PR TITLE
Add C Style comments to the parser

### DIFF
--- a/include/strutils.h
+++ b/include/strutils.h
@@ -23,8 +23,9 @@ static inline std::string &rtrim(std::string &s) {
 // Trim a C style comment that begins with '//'
 static inline std::string &rcomment(std::string &s) {
   auto p = s.rfind("//");
-  if (p != std::string::npos)
+  if (p != std::string::npos) {
     s.erase(p);
+  }
   return s;
 }
 

--- a/include/strutils.h
+++ b/include/strutils.h
@@ -20,6 +20,14 @@ static inline std::string &rtrim(std::string &s) {
         return s;
 }
 
+// Trim a C style comment that begins with '//'
+static inline std::string &rcomment(std::string &s) {
+  auto p = s.rfind("//");
+  if (p != std::string::npos)
+    s.erase(p);
+  return s;
+}
+
 // trim from both ends
 static inline std::string &trim(std::string &s) {
         return ltrim(rtrim(s));

--- a/src/SCParser.cpp
+++ b/src/SCParser.cpp
@@ -21,8 +21,10 @@ namespace Sigma {
 			Sigma::parser::Entity* currentEntity = nullptr;
 
 			while (getline(in, line)) {
-                // strip line's whitespace
-                line = rtrim(line);
+        // strip line's whitespace
+        line = rtrim(line);
+        // Strip C style comments
+        line = rcomment(line);
 
 				char key[1];
 				key[0] = line.substr(0,1)[0];


### PR DESCRIPTION
Allow to put comments in the .sc files using '//' to mark a comment. It will ignore the // to the end of the line.
