### PR TITLE
Fix OS X build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Sigma on OS X requires a [patched version](https://github.com/DeVaukz/SOIL) of S
 
 	git clone https://github.com/DeVaukz/SOIL.git
 	cd SOIL
-	cmake .. -G "Unix Makefiles"
+	cmake . -G "Unix Makefiles"
 	make -j10 && sudo make install 
 
 Awesomium is only distributed in binary form.  Download and run the installer from the [Awesomium website](http://www.awesomium.com/). 
@@ -137,4 +137,4 @@ cd build/
 cmake .. -G Xcode
 ```
 
-You must change the current scheme to Sigma by clicking on the scheme popup menu and selecting Sigma.  You can also change the working directory used when Sigma is started by Xcode.  Select Edit Scheme from the scheme popup menu, check the box next to Working Directory, and enter the path to the Sigma assets in the text field.
+You must change the current scheme to Sigma by clicking on the scheme popup menu and selecting Sigma.  You can also change the working directory used when Sigma is started by Xcode.  Select Edit Scheme from the scheme popup menu, switch to the Options tab, check the box next to Working Directory, and enter the path to the Sigma assets in the text field.

--- a/modules/FindGLFW3.cmake
+++ b/modules/FindGLFW3.cmake
@@ -33,7 +33,7 @@ ELSE(WIN32)
 	ENDIF(APPLE)
 
 	FIND_LIBRARY( GLFW3_LIBRARY
-        NAMES libglfw.so libglfw.so.3 libglfw.so.3.0 glfw3
+        NAMES libglfw.so libglfw.so.3 libglfw.so.3.0 glfw.3 glfw3
 		PATHS
 		/usr/lib64
 		/usr/lib


### PR DESCRIPTION
https://github.com/adam4813/Sigma/commit/3dd8548563460a00c3ceb7290a041e4922756512 broke the Sigma build on OS X by removing 'glfw' from the library names list.  This PR adds 'glfw.3', which is what OS X should have been using from the start.
