### PR TITLE
Fix a bug with Sigma on retina macs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(MINGW OR UNIX OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux") # *nix compliant
 	endif(NOT ${AWESOMIUM_FOUND})
 endif(MINGW OR UNIX OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-SET(OSX_CF_LIBRARY "")
+SET(OSX_LIBRARIES "")
 
 if(APPLE) # Mac OSX
 	SET(GLEW_LIBRARY "")
@@ -177,8 +177,8 @@ if(APPLE) # Mac OSX
 	# Can deploy back to 10.7, the first OS X to support the GL Core.
 	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
 
-	# Need Core Foundation
-	set(OSX_CF_LIBRARY "-framework CoreFoundation")
+	# Need Core Foundation and libobjc.
+	set(OSX_LIBRARIES "-framework CoreFoundation /usr/lib/libobjc.dylib")
 
 	if(NOT XCODE_VERSION)
 		# Yuck. The Makefile generator is not emitting a -F/Path/To/Awesomium flag.
@@ -192,7 +192,7 @@ endif(APPLE)
 add_executable(Sigma ${Sigma_SRC} ${Sigma_SRC_COMPONENT_H} ${Sigma_SRC_COMPONENT_CPP} ${Sigma_SRC_SYSTEM_H} ${Sigma_SRC_SYSTEM_CPP} ${Sigma_SRC_CONTROLLERS_H} ${Sigma_SRC_CONTROLLERS_CPP} ${Sigma_SRC_RESOURCES_H})
 
 # Link the executable to all required libraries
-target_link_libraries (Sigma ${OPENGL_LIBRARIES} ${GLFW3_LIBRARY} ${OGGVORBIS_LIBRARIES} ${OPENAL_LIBRARY} ${X11_LIBRARIES} ${OSX_CF_LIBRARY} ${GLEW_LIBRARY} ${SOIL_LIBRARY} ${BULLET_LINEARMATH_LIBRARIES} ${BULLET_COLLISION_LIBRARIES} ${BULLET_DYNAMICS_LIBRARIES} ${AWESOMIUM_LIBRARY})
+target_link_libraries (Sigma ${OPENGL_LIBRARIES} ${GLFW3_LIBRARY} ${OGGVORBIS_LIBRARIES} ${OPENAL_LIBRARY} ${X11_LIBRARIES} ${OSX_LIBRARIES} ${GLEW_LIBRARY} ${SOIL_LIBRARY} ${BULLET_LINEARMATH_LIBRARIES} ${BULLET_COLLISION_LIBRARIES} ${BULLET_DYNAMICS_LIBRARIES} ${AWESOMIUM_LIBRARY})
 
 # build the Tests subproject
 #ADD_SUBDIRECTORY("${CMAKE_SOURCE_DIR}/tests")

--- a/src/OS.cpp
+++ b/src/OS.cpp
@@ -2,6 +2,17 @@
 
 #include <iostream>
 
+#ifdef __APPLE__
+// Needed so we can disable retina support for our window.
+#define GLFW_EXPOSE_NATIVE_COCOA 1
+#define GLFW_EXPOSE_NATIVE_NSGL 1
+#include <GLFW/glfw3native.h>
+// We can't just include objc/runtime.h and objc/message.h because glfw is too forward thinking for its own good.
+typedef void* SEL;
+extern "C" id objc_msgSend(id self, SEL op, ...);
+extern "C" SEL sel_getUid(const char *str);
+#endif
+
 namespace Sigma {
 	bool OS::InitializeWindow(const int width, const int height, const std::string title, const unsigned int glMajor /*= 3*/, const unsigned int glMinor /*= 2*/) {
 		// Initialize the library.
@@ -31,6 +42,13 @@ namespace Sigma {
 
 		this->width = width;
 		this->height = height;
+        
+#ifdef __APPLE__
+        // Force retina displays to create a 1x framebuffer so we don't choke our fillrate.
+        id cocoaWindow = glfwGetCocoaWindow(this->window);
+        id cocoaGLView = ((id (*)(id, SEL)) objc_msgSend)(cocoaWindow, sel_getUid("contentView"));
+        ((void (*)(id, SEL, bool)) objc_msgSend)(cocoaGLView, sel_getUid("setWantsBestResolutionOpenGLSurface:"), false);
+#endif
 
 		// Make the window's context current.
 		glfwMakeContextCurrent(this->window);


### PR DESCRIPTION
Force macs with retina displays to create a 1x size frame buffer backing the window.  Fixes a problem where the viewport would only occupy the bottom left 1/4 of the window on a retina display.
