### PR TITLE
Added collision mesh scaling.

### DIFF
--- a/include/components/BulletShapeMesh.h
+++ b/include/components/BulletShapeMesh.h
@@ -13,7 +13,10 @@ namespace Sigma{
 			}
 		}
 
+		void SetMesh(const GLMesh* mesh, btVector3* scale);
+		void SetMesh(const GLMesh* mesh, float scale);
 		void SetMesh(const GLMesh* mesh);
+
 	private:
 		btTriangleMesh* btmesh;
 	};

--- a/src/components/BulletShapeMesh.cpp
+++ b/src/components/BulletShapeMesh.cpp
@@ -2,7 +2,8 @@
 #include "components/GLMesh.h"
 
 namespace Sigma {
-	void Sigma::BulletShapeMesh::SetMesh(const GLMesh* mesh) {
+
+	void Sigma::BulletShapeMesh::SetMesh(const GLMesh* mesh, btVector3* scale) {
 		this->btmesh = new btTriangleMesh();
 		for (unsigned int i = 0; i < mesh->GetFaceCount(); ++i) {
 			const Sigma::Face* f = mesh->GetFace(i);
@@ -12,6 +13,16 @@ namespace Sigma {
 			this->btmesh->addTriangle(btVector3(v1->x, v1->y, v1->z), btVector3(v2->x, v2->y, v2->z), btVector3(v3->x, v3->y, v3->z));
 		}
 
-		this->shape = new btBvhTriangleMeshShape(this->btmesh, false);
+		this->shape = new btScaledBvhTriangleMeshShape(new btBvhTriangleMeshShape(this->btmesh, false),	*scale);
+	}
+
+	// convinence function for an even scale accross all dimensions
+	void Sigma::BulletShapeMesh::SetMesh(const GLMesh* mesh, const float scale) {
+		SetMesh(mesh, new btVector3(scale, scale, scale));
+	}
+	
+	// for backward compatibility, uses scale = 1.0f
+	void Sigma::BulletShapeMesh::SetMesh(const GLMesh* mesh) {
+		SetMesh(mesh, 1.0f);
 	}
 }

--- a/src/systems/BulletPhysics.cpp
+++ b/src/systems/BulletPhysics.cpp
@@ -62,7 +62,10 @@ namespace Sigma {
 		for (auto propitr = properties.begin(); propitr != properties.end(); ++propitr) {
 			const Property*  p = &*propitr;
 
-			if (p->GetName() == "x") {
+			if (p->GetName() == "scale") {
+				scale = p->Get<float>();
+			}
+			else if (p->GetName() == "x") {
 				x = p->Get<float>();
 			}
 			else if (p->GetName() == "y") {
@@ -84,7 +87,7 @@ namespace Sigma {
 				std::cerr << "Loading mesh: " << p->Get<std::string>() << std::endl;
 				GLMesh meshFile(0);
 				meshFile.LoadMesh(p->Get<std::string>());
-				mesh->SetMesh(&meshFile);
+				mesh->SetMesh(&meshFile, scale);
 			}
 		}
 		mesh->InitializeRigidBody(x, y, z, rx, ry, rz);


### PR DESCRIPTION
Adds scaling to BulletShapeMeshs on creation, so for instance adding the following to `test.sc` (after the `@ship` declaration) will cause the in-game ship to be solid.

```
&BulletShapeMesh
>scale=0.1f
>z=-3.0f
>y=0.75f
>x=-18.0f
>meshFile=shipobj/ship.objs
```
