### PR TITLE
Added a Logger to Sigma, that can outputs to std::cout or any other ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,28 +236,39 @@ if(BUILD_EXE_Sigma)
 	# add the test executable, include the test app source containing main()
 
 	# if we are building a library of Sigma just link that and the includes
-	if(BUILD_STATIC_Sigma)
-		ADD_EXECUTABLE(Sigma
-			${Sigma_ALL_INCLUDES}
-			${Sigma_SRC_TESTS_CPP}
-			)
-		TARGET_LINK_LIBRARIES(Sigma libSigmas)
-	elseif(BUILD_SHARED_Sigma)
-		ADD_EXECUTABLE(Sigma
-			${Sigma_ALL_INCLUDES}
-			${Sigma_SRC_TESTS_CPP}
-			)
-		TARGET_LINK_LIBRARIES(Sigma libSigma)
-	else(BUILD_STATIC_Sigma)
-		# if just building an exe use all the source and libraries
-		ADD_EXECUTABLE(Sigma
-			${Sigma_ALL_SOURCE}
-			${Sigma_ALL_INCLUDES}
-			${Sigma_SRC_TESTS_CPP}
-			)
-		# Link the executable to all required libraries
-		TARGET_LINK_LIBRARIES(Sigma ${Sigma_ALL_LIBS})
-	endif(BUILD_STATIC_Sigma)
+	FOREACH(TEST_CPP ${Sigma_SRC_TESTS_CPP})
+		GET_FILENAME_COMPONENT(TEST_NAME ${TEST_CPP} NAME_WE)
+		if(TEST_NAME STREQUAL "main")
+			SET(TEST_NAME "Sigma")
+		endif(TEST_NAME STREQUAL "main")
+
+		MESSAGE(STATUS "Processing: ${TEST_NAME}")
+
+		if(BUILD_STATIC_Sigma)
+			ADD_EXECUTABLE(${TEST_NAME}
+				${Sigma_ALL_INCLUDES}
+				${TEST_CPP}
+				)
+			TARGET_LINK_LIBRARIES(${TEST_NAME} libSigmas)
+
+		elseif(BUILD_SHARED_Sigma)
+			ADD_EXECUTABLE(${TEST_NAME}
+				${Sigma_ALL_INCLUDES}
+				${TEST_CPP}
+				)
+			TARGET_LINK_LIBRARIES(${TEST_NAME} libSigma)
+
+		else(BUILD_STATIC_Sigma)
+			# if just building an exe use all the source and libraries
+			ADD_EXECUTABLE(${TEST_NAME}
+				${Sigma_ALL_SOURCE}
+				${Sigma_ALL_INCLUDES}
+				${TEST_CPP}
+				)
+			# Link the executable to all required libraries
+			TARGET_LINK_LIBRARIES(${TEST_NAME} ${Sigma_ALL_LIBS})
+		endif(BUILD_STATIC_Sigma)
 	
+		ENDFOREACH(TEST_CPP)
 endif(BUILD_EXE_Sigma)
 

--- a/include/Log.h
+++ b/include/Log.h
@@ -1,0 +1,145 @@
+#pragma once
+#ifndef __LOGGER_H_
+#define __LOGGER_H_ 1
+/**
+ * \brief Quick and dirty toy logger. Better that nothing
+ * 
+ * Requires to call Init, to setup the logger.
+ * Change the log level with SetLevel to any Log::LogLevel enumration value. By default is at Debug Level.
+ * If the output stream is a file, is recomend to use RAII (opening it at the begin of the main function)
+ * to avoid problems of not closing the file. The Logger not cloes the file or open it, only writes to it.
+ *
+ * Check src/tests/Log.cpp as a example of usage
+ */
+
+#include <iostream>
+#include <memory>
+
+namespace Log {
+
+	/**
+	 * Logging levels
+	 */
+	enum class LogLevel {
+		OFF = -1,
+		ERROR = 0,
+		WARN = 1,
+		INFO = 2,
+		DEBUG = 3,
+	};
+
+	/**
+	 * \brief Desired Logging level to show.
+	 * If N in "debug(N)" is <= log_level, when will be show
+	 * By default is at Debug level, displaying all log messages
+	 */
+	static LogLevel log_level = LogLevel::DEBUG;
+
+	/**
+	 * \brief Output stream to use
+	 * If is a file, the external code must open it and close it
+	 */
+	static std::ostream* out;
+	
+	/**
+	 * Initializes the Logger
+	 * \param level Logger level. By default is at Debug level
+	 * \param sout Output Streambuffer were to write. By default uses std::clog
+	 */
+	static void Init(LogLevel level = LogLevel::DEBUG) {
+		Log::log_level = level;
+		Log::out = &std::clog;
+	}
+			
+	/**
+	 * Initializes the Logger
+	 * \param level Logger level. By default is at Debug level
+	 * \param sout Output Streambuffer were to write. By default uses std::clog
+	 */
+	static void Init(std::ostream& sout, LogLevel level = LogLevel::DEBUG) {
+		Log::log_level = level;
+		Log::out = &sout;
+	}
+			
+	/**
+	 * Changes the actual logging level
+	 */
+	static void Level( LogLevel level) {
+		Log::log_level = level;
+	}
+
+	class Print {
+		public:
+
+			/**
+			 * /brief Builds a instance of the logger
+			 * /param level Logging level of the message
+			 */
+			Print( LogLevel level ) : 
+					output( level <= Log::log_level ), level(level) {
+				
+				if( output ) {
+					switch (level) {
+						case LogLevel::ERROR:
+							*Log::out << "[ERROR] ";
+							break;
+
+						case LogLevel::WARN:
+							*Log::out << "[WARNING] ";
+							break;
+
+						case LogLevel::INFO:
+							*Log::out << "[INFO] ";
+							break;
+
+						case LogLevel::DEBUG:
+							*Log::out << "[DEBUG] ";
+							break;
+
+						default:
+							break;
+					}
+					// Auto ident more if is more severe
+					//logger::out << std::string( static_cast<int>(logger::log_level) -
+					// static_cast<int>(level), '\t');
+				}
+			}
+
+			/**
+			 * \brief Dectructor of the class. Here writes the outpot
+			 */
+			~Print() {
+				if (output) {
+					*Log::out << std::endl;
+					Log::out->flush();
+				}
+			}
+
+			/**
+			 * \brief Opertaor << to write strings at the C++ way. Allow to chain multiple strings or values
+			 */
+			template<typename T>
+				Print& operator<<( T t) {
+					if( output ) {
+						*Log::out << t;
+						return *this;
+					}
+					return *this;
+				}
+
+		private:
+			bool output;    /// Enable output ?
+			LogLevel level; /// Level of the message
+
+	};
+
+} // END OF NAMESPACE logger
+
+// Macros to type less
+#define LOG_DEBUG Log::Print(Log::LogLevel::DEBUG)
+#define LOG       Log::Print(Log::LogLevel::INFO)
+#define LOG_WARN  Log::Print(Log::LogLevel::WARN)
+#define LOG_ERROR Log::Print(Log::LogLevel::ERROR)
+
+
+#endif // __LOGGER_H_

--- a/src/tests/Log.cpp
+++ b/src/tests/Log.cpp
@@ -29,7 +29,7 @@ int main () {
 	LOG_ERROR << "404!";
 
 	Log::Level(Log::LogLevel::WARN);	
-	LOG_DEBUG << "You should see this";
+	LOG_DEBUG << "You shouldn't see this";
 	LOG				<< "Too verbose...";
 	LOG_WARN	<< "Alarm!";
 	LOG_ERROR << "Dave, don't do that";

--- a/src/tests/Log.cpp
+++ b/src/tests/Log.cpp
@@ -1,0 +1,38 @@
+#include "Log.h"
+#include <fstream>
+
+int main () {
+	{
+		// Example setting the output to a file
+		std::ofstream f("log.txt", std::ios::app);
+		Log::Init(f);
+		
+		LOG_DEBUG << "Hello world!";
+		LOG				<< "Hello world!";
+		LOG_WARN	<< "Hello world!";
+		LOG_ERROR << "Hello world!";
+
+		Log::Level(Log::LogLevel::WARN);	
+		LOG_DEBUG << "Hello world! 2";
+		LOG				<< "Hello world! 2";
+		LOG_WARN	<< "Hello world! 2";
+		LOG_ERROR << "Hello world! 2";
+	
+	} // RAII closes the file here
+
+	// Default behaviur. outputs to std::clog (std::cerr)
+	Log::Init();
+	
+	LOG_DEBUG << "Hi mom!";
+	LOG				<< "Yo should know that";
+	LOG_WARN	<< "Danger Will Robinson";
+	LOG_ERROR << "404!";
+
+	Log::Level(Log::LogLevel::WARN);	
+	LOG_DEBUG << "You should see this";
+	LOG				<< "Too verbose...";
+	LOG_WARN	<< "Alarm!";
+	LOG_ERROR << "Dave, don't do that";
+
+	return 0;
+}


### PR DESCRIPTION
...output stream. Also there a little addition in CMakeFileLists.txt to allow to generate a executable for each one .cpp file in src/tests/

This should unify all output stuff and avoid something like It's said in Issue #93

An example of usage : 

```
int main () {
    std::ofstream f("log.txt", std::ios::app);
    Log::Init(f);
    ...
    LOG_DEBUG << "Hello world!"; // Appends to log.txt -> [DEBUG] Hello world!
    LOG << "Hello world!"; // [INFO] Hello world!
    LOG_WARN << "Hello world!"; // [WARNING] Hello world!
    LOG_ERROR << "Hello world!"; // [ERROR] Hello world!
    ...
    Log::Level(Log::LogLevel::WARN); // Change filtering level
    LOG_DEBUG << "Hello world! 2"; // This is not logged
    LOG << "Hello world! 2"; // Idem
    LOG_WARN << "Hello world! 2"; // But this yes as <= that the Log Level
    LOG_ERROR << "Hello world! 2"; // Idem
    ...
} // RAII closes the log.txt file
```
