### PR TITLE
Replaced all std::cout and std::cerr log messages to calls to Logger.

### DIFF
--- a/include/Log.h
+++ b/include/Log.h
@@ -13,7 +13,9 @@
  */
 
 #include <iostream>
+#include <string>
 #include <memory>
+#include <cassert>
 
 namespace Log {
 
@@ -28,79 +30,83 @@ namespace Log {
 		DEBUG = 3,
 	};
 
-	/**
-	 * \brief Desired Logging level to show.
-	 * If N in "debug(N)" is <= log_level, when will be show
-	 * By default is at Debug level, displaying all log messages
-	 */
-	static LogLevel log_level = LogLevel::DEBUG;
-
-	/**
-	 * \brief Output stream to use
-	 * If is a file, the external code must open it and close it
-	 */
-	static std::ostream* out;
-	
-	/**
-	 * Initializes the Logger
-	 * \param level Logger level. By default is at Debug level
-	 * \param sout Output Streambuffer were to write. By default uses std::clog
-	 */
-	static void Init(LogLevel level = LogLevel::DEBUG) {
-		Log::log_level = level;
-		Log::out = &std::clog;
-	}
-			
-	/**
-	 * Initializes the Logger
-	 * \param level Logger level. By default is at Debug level
-	 * \param sout Output Streambuffer were to write. By default uses std::clog
-	 */
-	static void Init(std::ostream& sout, LogLevel level = LogLevel::DEBUG) {
-		Log::log_level = level;
-		Log::out = &sout;
-	}
-			
-	/**
-	 * Changes the actual logging level
-	 */
-	static void Level( LogLevel level) {
-		Log::log_level = level;
-	}
 
 	class Print {
+		private:
+			bool output;    /// Enable output ?
+			LogLevel level; /// Level of the message
+			
+			/**
+			 * \brief Desired Logging level to show.
+			 * If N in "debug(N)" is <= log_level, when will be show
+			 * By default is at Debug level, displaying all log messages
+			 */
+			static LogLevel log_level;
+
+			/**
+			 * \brief Output stream to use
+			 * If is a file, the external code must open it and close it
+			 */
+			static std::ostream* out;
+
 		public:
+			/**
+			 * Initializes the Logger
+			 * \param level Logger level. By default is at Debug level
+			 * \param sout Output Streambuffer were to write. By default uses std::clog
+			 */
+			static void Init(LogLevel level = LogLevel::DEBUG) {
+				log_level = level;
+				out = &std::clog;
+			}
+					
+			/**
+			 * Initializes the Logger
+			 * \param level Logger level. By default is at Debug level
+			 * \param sout Output Streambuffer were to write. By default uses std::clog
+			 */
+			static void Init(std::ostream& sout, LogLevel level = LogLevel::DEBUG) {
+				log_level = level;
+				out = &sout;
+			}
+					
+			/**
+			 * Changes the actual logging level
+			 */
+			static void Level( LogLevel level) {
+				log_level = level;
+			}
 
 			/**
 			 * /brief Builds a instance of the logger
 			 * /param level Logging level of the message
 			 */
 			Print( LogLevel level ) : 
-					output( level <= Log::log_level ), level(level) {
+					output( level <= log_level ), level(level) {
 				
 				if( output ) {
 					switch (level) {
 						case LogLevel::ERROR:
-							*Log::out << "[ERROR] ";
+							*out << "[ERROR] ";
 							break;
 
 						case LogLevel::WARN:
-							*Log::out << "[WARNING] ";
+							*out << "[WARNING] ";
 							break;
 
 						case LogLevel::INFO:
-							*Log::out << "[INFO] ";
+							*out << "[INFO] ";
 							break;
 
 						case LogLevel::DEBUG:
-							*Log::out << "[DEBUG] ";
+							*out << "[DEBUG] ";
 							break;
 
 						default:
 							break;
 					}
 					// Auto ident more if is more severe
-					//logger::out << std::string( static_cast<int>(logger::log_level) -
+					//*out << std::string( static_cast<int>(logger::log_level) -
 					// static_cast<int>(level), '\t');
 				}
 			}
@@ -110,26 +116,31 @@ namespace Log {
 			 */
 			~Print() {
 				if (output) {
-					*Log::out << std::endl;
-					Log::out->flush();
+					*out << std::endl;
+					out->flush();
 				}
 			}
 
 			/**
-			 * \brief Opertaor << to write strings at the C++ way. Allow to chain multiple strings or values
+			 * \brief Opertaor << to write strings at the C++ way. Allow to chain multiple strings
+			 */
+			Print& operator<<(const std::string& str) {
+				if( output && out != nullptr ) {
+					*out << str;
+				}
+				return *this;
+			}
+
+			/**
+			 * \brief Opertaor << to write anything at the C++ way. Allow to chain multiple strings or values
 			 */
 			template<typename T>
-				Print& operator<<( T t) {
-					if( output ) {
-						*Log::out << t;
-						return *this;
-					}
-					return *this;
+			Print& operator<<( T t) {
+				if( output && out != nullptr ) {
+					*out << t;
 				}
-
-		private:
-			bool output;    /// Enable output ?
-			LogLevel level; /// Level of the message
+				return *this;
+			}
 
 	};
 

--- a/include/Sigma.h
+++ b/include/Sigma.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <stdint.h>
 
+#include "Log.h"
+
 // Put in this header all the things shared by all code
 namespace Sigma {
 	typedef uint32_t id_t;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1,0 +1,8 @@
+#include "Log.h"
+
+namespace Log {
+	// The Joker was here
+	LogLevel Print::log_level;
+	std::ostream* Print::out;
+}
+

--- a/src/SCParser.cpp
+++ b/src/SCParser.cpp
@@ -6,6 +6,8 @@
 #include <sstream>
 #include <locale.h>
 
+#include "Sigma.h"
+
 namespace Sigma {
 	namespace parser {
     /**
@@ -27,7 +29,7 @@ namespace Sigma {
 
 			// Some type of error opening the file
 			if (!in) {
-				std::cerr << "Cannot open sc file " << fname << std::endl;
+				LOG_ERROR << "Cannot open sc file " << fname;
 				return false;
 			}
 
@@ -99,7 +101,7 @@ namespace Sigma {
 						currentEntity->components.push_back(c);
 					}
 					else {
-						std::cerr << "Attempted to add component to undefined entity." << std::endl;
+						LOG_DEBUG << "Attempted to add component to undefined entity.";
 					}
 				}
 			}

--- a/src/SoundFile.cpp
+++ b/src/SoundFile.cpp
@@ -10,6 +10,8 @@ extern "C" {
 #include <string>
 #include "resources/SoundFile.h"
 
+#include "Sigma.h"
+
 struct OggLinkedPacket {
 	ogg_packet pack;
 	void * next;
@@ -129,7 +131,7 @@ namespace Sigma {
 							bytec = opdata->pack.bytes;
 							if(!offs) {
 								if(vorbis_synthesis_idheader(&opdata->pack) == 1) {
-									std::cerr << "\nVorbis ";
+									LOG << "\nVorbis ";
 									dataformat = Vorbis;
 								}
 							}
@@ -170,7 +172,7 @@ namespace Sigma {
 			}
 			if(lastlp) { lastlp->next = nullptr; }
 
-			std::cerr << datasz << " bytes loaded.";
+			LOG_DEBUG << datasz << " bytes loaded.";
 			ogg_stream_clear(&stream);
 			ogg_sync_clear(&sync);
 		}
@@ -456,8 +458,8 @@ namespace Sigma {
 						k = 0;
 						for(fidat = (float*)in, sodat = (short*)out; k++ < fcount; fidat++, sodat++) {
 							*(unsigned short*)sodat = static_cast<unsigned short>(((*fidat)+1.0f) * 16383.f);
-							if(*fidat < fmin) { std::cerr << "m" << *fidat; sodat--; }
-							if(*fidat > fmax) { std::cerr << "x" << *fidat; sodat--; }
+							if(*fidat < fmin) { LOG << "m" << *fidat; sodat--; }
+							if(*fidat > fmax) { LOG << "x" << *fidat; sodat--; }
 							if(chanadd) { fidat--; }
 							if(chancomp) { fidat++; }
 						}
@@ -487,15 +489,14 @@ namespace Sigma {
 				fh.read(fourcc.cvalue, 4); // read the id string
 				fh.seekg(0, std::ios::beg);
 				if(fourcc == FourCC('R','I','F','F')) {
-					std::cerr << "Loading Sound from WAV file: " << fn << '\n';
+					LOG << "Loading Sound from WAV file: " << fn << '\n';
 					LoadWAV(fh, sz);
 					ProcessMeta();
 				}
 				else if(fourcc == FourCC('O','g','g','S')) {
-					std::cerr << "Loading Sound from Ogg file: " << fn;
+					LOG << "Loading Sound from Ogg file: " << fn;
 					LoadOgg(fh, sz);
 					ProcessMeta();
-					std::cerr << '\n';
 				}
 				else {
 					data = (unsigned char*)malloc( (size_t)sz );

--- a/src/components/GLCubeSphere.cpp
+++ b/src/components/GLCubeSphere.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "Sigma.h"
+
 const float epsilon = 0.0001f;
 
 // For std::find
@@ -87,7 +89,7 @@ namespace Sigma {
 		std::string filenames[6];
         {
             // LOAD CUBE VISUAL TEXTURES
-			std::cout << "Loading cube texture: " << texture_name << std::endl;
+			LOG << "Loading cube texture: " << texture_name ;
 			sprintf(filename, "%s.dds", texture_name.c_str());
 
 			this->_cubeMap = SOIL_load_OGL_single_cubemap(filename, SOIL_DDS_CUBEMAP_FACE_ORDER, SOIL_LOAD_AUTO, SOIL_CREATE_NEW_ID, SOIL_FLAG_MIPMAPS | SOIL_FLAG_DDS_LOAD_DIRECT);
@@ -108,12 +110,12 @@ namespace Sigma {
 													   SOIL_LOAD_RGB, SOIL_CREATE_NEW_ID, SOIL_FLAG_MIPMAPS);
 
 				if( 0 == this->_cubeMap ) {
-					printf( "SOIL error loading cubemap: '%s'\n", SOIL_last_result() );
+					LOG_ERROR << "SOIL error loading cubemap: " << SOIL_last_result();
 				}
 			}
         }
         {
-			std::cout << "Loading cube normal map: " << texture_name << "_nm" << std::endl;
+			LOG << "Loading cube normal map: " << texture_name << "_nm" ;
 			// First try dds file
 			sprintf(filename, "%s_nm.dds", texture_name.c_str());
 

--- a/src/components/GLMesh.cpp
+++ b/src/components/GLMesh.cpp
@@ -207,7 +207,7 @@ namespace Sigma{
         std::ifstream in(fname, std::ios::in);
 
         if (!in) {
-            std::cerr << "Cannot open mesh " << fname << std::endl;
+            LOG_WARN << "Cannot open mesh " << fname;
             return false;
         }
 
@@ -330,7 +330,7 @@ namespace Sigma{
 			else { // Unknown
                 /* ignoring this line */
                 std::string test = line.substr(0, line.find(' '));
-                std::cerr << "Unrecognized line " << line << std::endl;
+                LOG_WARN << "Unrecognized line " << line;
             }
         }
 
@@ -437,7 +437,7 @@ namespace Sigma{
 		std::ifstream in(fname, std::ios::in);
 
         if (!in) {
-            std::cerr << "Cannot open material " << fname << std::endl;
+            LOG_WARN << "Cannot open material " << fname;
             return;
         }
 
@@ -492,7 +492,7 @@ namespace Sigma{
 						s >> filename;
 						filename = trim(filename);
 						filename = convert_path(filename);
-						std::cerr << "Loading diffuse texture: " << path + filename << std::endl;
+						LOG << "Loading diffuse texture: " << path + filename;
 						resource::GLTexture texture;
 						if (OpenGLSystem::textures.find(filename) == OpenGLSystem::textures.end()) {
 							texture.LoadDataFromFile(path + filename);
@@ -507,7 +507,7 @@ namespace Sigma{
 						}
 
 						if (m.diffuseMap == 0) {
-							std::cerr << "Error loading diffuse texture: " << path + filename << std::endl;
+							LOG_WARN << "Error loading diffuse texture: " << path + filename;
 						}
                     }
 					else if (label == "map_Ka") {
@@ -515,7 +515,7 @@ namespace Sigma{
 						s >> filename;
 						filename = trim(filename);
 						filename = convert_path(filename);
-						std::cerr << "Loading ambient texture: " << path + filename << std::endl;
+						LOG << "Loading ambient texture: " << path + filename;
 						// Add the path to the filename to load it relative to the mtl file
 						resource::GLTexture texture;
 						if (OpenGLSystem::textures.find(filename) == OpenGLSystem::textures.end()) {
@@ -532,7 +532,7 @@ namespace Sigma{
 
 						// Add the path to the filename to load it relative to the mtl file
 						if (m.ambientMap == 0) {
-							std::cerr << "Error loading ambient texture: " << path + filename << std::endl;
+							LOG_WARN << "Error loading ambient texture: " << path + filename;
 						}
                     }
 					else if (label == "map_Bump") {
@@ -540,7 +540,7 @@ namespace Sigma{
 						s >> filename;
 						filename = trim(filename);
 						filename = convert_path(filename);
-						std::cerr << "Loading normal or bump texture: " << path + filename << std::endl;
+						LOG << "Loading normal or bump texture: " << path + filename;
 						// Add the path to the filename to load it relative to the mtl file
 						resource::GLTexture texture;
 						if (OpenGLSystem::textures.find(filename) == OpenGLSystem::textures.end()) {
@@ -557,7 +557,7 @@ namespace Sigma{
 
 						// Add the path to the filename to load it relative to the mtl file
 						if (m.normalMap == 0) {
-							std::cerr << "Error loading normal texture: " << path + filename << std::endl;
+							LOG_WARN << "Error loading normal texture: " << path + filename;
 						}
                     }
 					else {

--- a/src/components/GLScreenQuad.cpp
+++ b/src/components/GLScreenQuad.cpp
@@ -1,6 +1,8 @@
 #include "components/GLScreenQuad.h"
 #include "resources/GLTexture.h"
 
+#include "Sigma.h"
+
 namespace Sigma {
 	GLScreenQuad::GLScreenQuad(const id_t  entityID) : GLMesh(entityID), texture(nullptr), x(0), y(0), w(0), h(0), inverted(false) {}
 	GLScreenQuad::~GLScreenQuad() {}

--- a/src/os/sdl/SDLSys.cpp
+++ b/src/os/sdl/SDLSys.cpp
@@ -3,6 +3,7 @@
 #include "GL/glew.h"
 #include "SDL_opengl.h"
 
+#include "Sigma.h"
 
 Sigma::event::KeyboardInputSystem IOpSys::KeyboardEventSystem;
 Sigma::event::MouseInputSystem IOpSys::MouseEventSystem;
@@ -10,7 +11,7 @@ Sigma::event::MouseInputSystem IOpSys::MouseEventSystem;
 //double IOpSys::curDelta;
 
 void* SDLSys::CreateGraphicsWindow(const unsigned int width, const unsigned int height) {
-    std::cout << "Creating Window using SDL..." << std::endl;
+    LOG << "Creating Window using SDL...";
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
@@ -27,8 +28,8 @@ void* SDLSys::CreateGraphicsWindow(const unsigned int width, const unsigned int 
 
     GLenum glew_err = glewInit();
     if (glew_err != GLEW_OK) {
-        fprintf(stderr, "GLEW Error: %s\n", glewGetErrorString(glew_err));
-        return 0;
+			LOG_ERROR << "GLEW Error: " << glewGetErrorString(glew_err);
+      return 0;
     }
 
     this->Fullscreen = false;
@@ -38,11 +39,11 @@ void* SDLSys::CreateGraphicsWindow(const unsigned int width, const unsigned int 
     // Set the relative mouse state (hide mouse)
     /*
     if(SDL_SetRelativeMouseMode(SDL_FALSE) < 0){
-        std::cerr << "ERROR: SDL could not grab mouse\n" << SDL_GetError() << std::endl;
+        LOG_ERROR << "ERROR: SDL could not grab mouse\n" << SDL_GetError();
     } */
     // relative mode was breaking things, just hide mouse.
     if(SDL_ShowCursor(SDL_DISABLE) < 0) {
-        std::cerr << "ERROR: SDL could not hide mouse\n" << SDL_GetError() << std::endl;
+      LOG_ERROR << "ERROR: SDL could not hide mouse\n" << SDL_GetError();
     }
 
     return &this->_Context;
@@ -227,7 +228,7 @@ void SDLSys::LoadFont(std::string file, unsigned int ptSize) {
 	this->font = TTF_OpenFont(file.c_str(), ptSize);
 
 	if(!this->font) {
-		std::cerr << "Error loading font: " << TTF_GetError() << std::endl;
+		LOG_ERROR << "Error loading font: " << TTF_GetError();
 	}
 
 	TTF_SetFontKerning(this->font, 0);
@@ -247,7 +248,7 @@ void SDLSys::RenderText(std::string text, float x, float y, unsigned int texture
 		textSurface = TTF_RenderText_Blended(this->font, text.c_str(), color);
 
 		if(!textSurface) {
-			std::cerr << "TTF Error: " << TTF_GetError();
+			LOG_ERROR << "TTF Error: " << TTF_GetError();
 			return;
 		} else {
 			// Note: width should not exceed the texture's size,
@@ -271,7 +272,7 @@ void SDLSys::RenderText(std::string text, float x, float y, unsigned int texture
 				// Copy it over
 				glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, convertSurface->w, convertSurface->h, GL_BGRA, GL_UNSIGNED_BYTE, convertSurface->pixels);
 			} else {
-				std::cerr << SDL_GetError() << std::endl;
+				LOG_ERROR << SDL_GetError();
 			}
 
 		

--- a/src/systems/BulletPhysics.cpp
+++ b/src/systems/BulletPhysics.cpp
@@ -98,7 +98,7 @@ namespace Sigma {
 				rz = p->Get<float>();
 			}
 			else if (p->GetName() == "meshFile") {
-				std::cerr << "Loading mesh: " << p->Get<std::string>() << std::endl;
+				LOG << "Loading mesh: " << p->Get<std::string>();
 				GLMesh meshFile(0);
 				meshFile.LoadMesh(p->Get<std::string>());
 				mesh->SetMesh(&meshFile, scale);

--- a/src/systems/FactorySystem.cpp
+++ b/src/systems/FactorySystem.cpp
@@ -1,4 +1,5 @@
 #include "systems/FactorySystem.h"
+#include "Sigma.h"
 
 namespace Sigma{
 
@@ -26,20 +27,20 @@ namespace Sigma{
                                const id_t entityID,
                                const std::vector<Property> &properties){
         if(registeredFactoryFunctions.find(type) != registeredFactoryFunctions.end()){
-			std::cerr << "Creating component of type: " << type << std::endl;
+						LOG << "Creating component of type: " << type;
             return registeredFactoryFunctions[type](entityID, properties);
         } else{
-            std::cerr << "Error: Couldn't find component: " << type << std::endl;
+            LOG_DEBUG << "Error: Couldn't find component: " << type;
             return nullptr;
         }
     }
 
     void FactorySystem::register_Factory(IFactory& Factory){
-		const auto& factoryfunctions = Factory.getFactoryFunctions();
-		for(auto FactoryFunc = factoryfunctions.begin(); FactoryFunc != factoryfunctions.end(); ++FactoryFunc){
-			std::cerr << "Registering component factory of type: " << FactoryFunc->first << std::endl;
-            registeredFactoryFunctions[FactoryFunc->first]=FactoryFunc->second;
-        }
-    }
+			const auto& factoryfunctions = Factory.getFactoryFunctions();
+			for(auto FactoryFunc = factoryfunctions.begin(); FactoryFunc != factoryfunctions.end(); ++FactoryFunc){
+				LOG << "Registering component factory of type: " << FactoryFunc->first ;
+				registeredFactoryFunctions[FactoryFunc->first]=FactoryFunc->second;
+			}
+		}
 
 } // namespace Sigma

--- a/src/systems/GLSLShader.cpp
+++ b/src/systems/GLSLShader.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <fstream>
 
+#include "Sigma.h"
+
 GLSLShader::GLSLShader(void)
 {
 	_totalShaders=0;
@@ -38,7 +40,7 @@ void GLSLShader::LoadFromString(GLenum type, const std::string source) {
 		glGetShaderiv (shader, GL_INFO_LOG_LENGTH, &infoLogLength);
 		GLchar *infoLog= new GLchar[infoLogLength];
 		glGetShaderInfoLog (shader, infoLogLength, NULL, infoLog);
-		std::cerr<<"Compile log: "<<infoLog<<std::endl;
+		LOG_WARN << "Compile log: " << infoLog;
 		delete [] infoLog;
 	}
 	_shaders[_totalShaders++]=shader;
@@ -73,7 +75,7 @@ void GLSLShader::CreateAndLinkProgram() {
 		glGetProgramiv (_program, GL_INFO_LOG_LENGTH, &infoLogLength);
 		GLchar *infoLog= new GLchar[infoLogLength];
 		glGetProgramInfoLog (_program, infoLogLength, NULL, infoLog);
-		std::cerr<<"Link log: "<<infoLog<<std::endl;
+		LOG_WARN << "Link log: " << infoLog;
 		delete [] infoLog;
 	}
 
@@ -118,6 +120,6 @@ void GLSLShader::LoadFromFile(GLenum whichShader, const std::string filename){
 		//copy to source
 		LoadFromString(whichShader, buffer);
 	} else {
-		std::cerr<<"Error loading shader: "<<filename<<std::endl;
+		LOG_ERROR << "Error loading shader: " << filename;
 	}
 }

--- a/src/systems/OpenALSystem.cpp
+++ b/src/systems/OpenALSystem.cpp
@@ -1,6 +1,8 @@
 #include "systems/OpenALSystem.h"
 #include <iostream>
 
+#include "Sigma.h"
+
 namespace Sigma {
 
 	// We need ctor and dstor to be exported to a dll even if they don't do anything
@@ -23,7 +25,7 @@ namespace Sigma {
 		}
 		alcx = alcGetString(device, ALC_EXTENSIONS);
 		if( alcx != nullptr ) {
-			std::cerr << "OpenAL extentions: " << alcx << '\n';
+			LOG << "OpenAL extentions: " << alcx;
 		}
 		return true;
 	}

--- a/src/systems/OpenGLSystem.cpp
+++ b/src/systems/OpenGLSystem.cpp
@@ -10,6 +10,8 @@
 #include "components/PointLight.h"
 #include "components/SpotLight.h"
 
+#include "Sigma.h"
+
 #ifdef __APPLE__
 // Do not include <OpenGL/glu.h> because that will include gl.h which will mask all sorts of errors involving the use of deprecated GL APIs until runtime.
 // gluErrorString (and all of glu) is deprecated anyway (TODO).
@@ -346,7 +348,6 @@ namespace Sigma{
 				continue;
 			}
 			else if (p->GetName() == "meshFile") {
-				std::cerr << "Loading mesh: " << p->Get<std::string>() << std::endl;
 				mesh->LoadMesh(p->Get<std::string>());
 			}
 			else if (p->GetName() == "shader") {
@@ -602,10 +603,11 @@ namespace Sigma{
 
 		switch(status) {
 		case GL_FRAMEBUFFER_COMPLETE:
-			std::cout << "Successfully created render target.";
+			LOG << "Successfully created render target.";
 			break;
 		default:
-			assert(0 && "Error: Framebuffer format is not compatible.");
+			LOG_ERROR << "Error: Framebuffer format is not compatible.";
+			assert (0 && "Error: Framebuffer format is not compatible.");
 		}
 
 		// Unbind objects
@@ -1054,7 +1056,7 @@ int printOglError(const std::string &file, int line) {
 
 	glErr = glGetError();
 	if (glErr != GL_NO_ERROR) {
-		std::cerr << "glError in file " << file << " @ line " << line << ": " << gluErrorString(glErr) << std::endl;
+		LOG_ERROR << "glError in file " << file << " @ line " << line << ": " << gluErrorString(glErr);
 		retCode = 1;
 	}
 	return retCode;

--- a/src/systems/WebGUISystem.cpp
+++ b/src/systems/WebGUISystem.cpp
@@ -5,6 +5,8 @@
 
 #include "cef_url.h"
 
+#include "Sigma.h"
+
 namespace Sigma {
 
 	// We need ctor and dstor to be exported to a dll even if they don't do anything
@@ -21,7 +23,7 @@ namespace Sigma {
 	}
 
 	bool WebGUISystem::Start(CefMainArgs& mainArgs) {
-		std::cout << "Setting up web view." << std::endl;
+		LOG << "Setting up web view.";
 		CefRefPtr<WebGUISystem> ourselves(this);
 		CefSettings settings;
 #ifdef _WIN32
@@ -73,7 +75,7 @@ namespace Sigma {
 		CefString cefurl(url);
 		CefURLParts parts;
 		if (!CefParseURL(cefurl, parts)) {
-			std::cerr << "Invalid URL" << std::endl;
+			LOG_WARN << "Invalid URL";
 		}
 
 		Sigma::resource::GLTexture texture;

--- a/src/tests/Log.cpp
+++ b/src/tests/Log.cpp
@@ -1,18 +1,23 @@
 #include "Log.h"
 #include <fstream>
 
+#include <string>
+#include <sstream>
+
+#include "strutils.h"
+
 int main () {
 	{
 		// Example setting the output to a file
 		std::ofstream f("log.txt", std::ios::app);
-		Log::Init(f);
+		Log::Print::Init(f);
 		
 		LOG_DEBUG << "Hello world!";
 		LOG				<< "Hello world!";
 		LOG_WARN	<< "Hello world!";
 		LOG_ERROR << "Hello world!";
 
-		Log::Level(Log::LogLevel::WARN);	
+		Log::Print::Level(Log::LogLevel::WARN);	
 		LOG_DEBUG << "Hello world! 2";
 		LOG				<< "Hello world! 2";
 		LOG_WARN	<< "Hello world! 2";
@@ -21,14 +26,35 @@ int main () {
 	} // RAII closes the file here
 
 	// Default behaviur. outputs to std::clog (std::cerr)
-	Log::Init();
-	
+	Log::Print::Init();
+
+	std::string str1("I'm big! I'm Muzzy! ");
+	std::string str2("diffuse.png");
+	std::string fname("assets/material.mtl");
+  str2 = trim(str2);
+	std::stringstream s(str2);
+	std::string filename;
+	s >> filename;
+	filename = trim(filename);
+	filename = convert_path(filename);
+
+	std::string path;
+	if (fname.find("/") != std::string::npos) {
+		path = fname.substr(0, fname.find_last_of("/") + 1); // Keep the separator.
+	}	else if (fname.find_last_of("\\") != std::string::npos) {
+		path = fname.substr(0, fname.find_last_of("\\") + 1); // Keep the separator.
+	}	else {
+		path = "";
+	}
+
 	LOG_DEBUG << "Hi mom!";
 	LOG				<< "Yo should know that";
 	LOG_WARN	<< "Danger Will Robinson";
 	LOG_ERROR << "404!";
+	LOG_ERROR << "String : " << str1;
+	LOG_ERROR << "String : " << path << filename;
 
-	Log::Level(Log::LogLevel::WARN);	
+	Log::Print::Level(Log::LogLevel::WARN);	
 	LOG_DEBUG << "You shouldn't see this";
 	LOG				<< "Too verbose...";
 	LOG_WARN	<< "Alarm!";

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -18,6 +18,8 @@
 #endif
 
 int main(int argCount, char **argValues) {
+	Log::Print::Init(); // Initiatin the Logger must the first thing
+
 	Sigma::WebGUISystem webguisys;
 
 	CefRefPtr<Sigma::WebGUISystem> app(&webguisys);
@@ -45,7 +47,7 @@ int main(int argCount, char **argValues) {
 	factory.register_Factory(webguisys);
 
 	if (!glfwos.InitializeWindow(1024, 768, "Sigma GLFW Test Window")) {
-		std::cerr << "Failed creating the window or context." << std::endl;
+		LOG_ERROR << "Failed creating the window or context.";
 		return -1;
 	}
 
@@ -53,17 +55,17 @@ int main(int argCount, char **argValues) {
 	// Start the openGL system //
 	/////////////////////////////
 
-	std::cout << "Initializing OpenGL system." << std::endl;
+	LOG << "Initializing OpenGL system.";
 	const int* version = glsys.Start();
 
 	glsys.SetViewportSize(glfwos.GetWindowWidth(), glfwos.GetWindowHeight());
 
 	if (version[0] == -1) {
-		std::cerr << "Error starting OpenGL!" << std::endl;
+		LOG_ERROR << "Error starting OpenGL!";
 		return -1;
 	}
 	else {
-		std::cout << "OpenGL version: " << version[0] << "." << version[1] << std::endl;
+		LOG << "OpenGL version: " << version[0] << "." << version[1];
 	}
 
 	//////////////////////////////
@@ -94,7 +96,7 @@ int main(int argCount, char **argValues) {
 	// Setup Sound //
 	/////////////////
 
-	std::cout << "Initializing OpenAL system." << std::endl;
+	LOG << "Initializing OpenAL system.";
 	alsys.Start();
 	alsys.test(); // try sound
 	
@@ -105,12 +107,13 @@ int main(int argCount, char **argValues) {
 	// Parse the scene file to retrieve entities
 	Sigma::parser::SCParser parser;
 
-	std::cout << "Parsing test.sc scene file." << std::endl;
+	LOG << "Parsing test.sc scene file.";
 	if (!parser.Parse("test.sc")) {
-		assert(0 && "Failed to load entities from file.");
+		LOG_ERROR << "Failed to load entities from file.";
+		exit (-1);
 	}
 
-	std::cout << "Generating Entities." << std::endl;
+	LOG << "Generating Entities.";
 
 	// Create each entity's components
 	for (unsigned int i = 0; i < parser.EntityCount(); ++i) {
@@ -198,6 +201,7 @@ int main(int argCount, char **argValues) {
 
 	FlashlightState fs = FL_OFF;
 
+	LOG << "Main loop begins ";
 	while (!glfwos.Closing()) {
 		// Get time in ms, store it in seconds too
 		double deltaSec = glfwos.GetDeltaTime();


### PR DESCRIPTION
Also, fixed Logger bug, moving static globar var to static private variables inside of Log::Print class

Now should not be any logging messages being output by calls to fprintf, printf, std::cout or std::cerr, closing totally the Issue #93. Now all this messages uses the Logger.

Probably, will be necessary tweaking the Log levels used in some places.
