### PR TITLE
CEF build and Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,7 @@ pip-log.txt
 ##################################
 ## Chromium Embedded Framework
 ##################################
+cef/
 include/capi/
 include/internal/
 include/wrapper/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,3 +276,9 @@ if(BUILD_EXE_Sigma)
 		ENDFOREACH(TEST_CPP)
 endif(BUILD_EXE_Sigma)
 
+# CEF has some files that need to be copied to ${CMAKE_BINARY_DIR}/bin
+ADD_CUSTOM_COMMAND(
+    TARGET Sigma POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${PROJECT_SOURCE_DIR}/cef/bin $<TARGET_FILE_DIR:Sigma>)
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Sigma requires the following dependencies:
 * [libvorbis](https://www.xiph.org/ogg/);
 
 Sigma on Linux also requires [GTK+ 2](http://www.gtk.org), due to usage of Chromium Embedded Framework.
+When building these libraries from source, always build them as shared objects (`.so`). In cmake-builds, this can be done using `cmake -DBUILD_SHARED_LIBS=ON`.
 
 You'll also need a [package of assets](http://wiki.trillek.org/wiki/Assets).  Unpack it in the build/bin/ directory.
 
@@ -36,13 +37,19 @@ You'll also need a [package of assets](http://wiki.trillek.org/wiki/Assets).  Un
 Make sure you use a binary release from [Adobe](http://www.cefbuilds.com). **Use the latest version that is NOT marked as dev (trunk).**
 
 1. Unzip the downloaded tarball.
-2. This step depends on your platform. On Windows, build the included `libcef_dll_wrapper.vcxproj` project. On Linux, run `make libcef_dll_wrapper BUILDTYPE=Release`. On OS X, use the `cefclient.xcodeproj` Xcode project. **Make sure to use the Release build mode.**
-3. Copy `out/Release/obj.target/libcef_dll_wrapper` directory, if any, and the contents of `Resources/` directories into Sigma's build/bin/.
-4. Copy the contents of include/ directory into Sigma's include/.
-5. Copy `out/Release/obj.target/libcef_dll_wrapper.a` (or .lib) to a `cef/` directory in the Sigma root (create the `cef/` directory if it does not exist)
-6. This step also depends on your platform. On Windows copy all the .dll files in `Release/` to Sigma's build/bin/, then copy the .lib file into Sigma's `cef/` directory. On Linux or OS X copy the entire contents of `Release/` into Sigma's build/bin/.
-7. On Linux and OSX, make a symlink pointing to libcef.so (or .dylib) in the `cef/` directory.
-8. If you get the error "malformed archive" when building, make a symlink pointing to libcef_dll_wrapper directory in the `cef/` directory.
+2. This step depends on your platform. 
+    * __Windows__ build the included `libcef_dll_wrapper.vcxproj` project
+    * __Linux__ run `make libcef_dll_wrapper BUILDTYPE=Release`
+    * __OS X__ use the `cefclient.xcodeproj` Xcode project. **Make sure to use the Release build mode.**
+3. Make `cef/` and `cef/bin/` directories in `Sigma/`
+4. Copy the `out/Release/obj.target/libcef_dll_wrapper` directory, if any, and the contents of `Resources/` directories into `Sigma/cef/bin/`
+5. Copy the contents of include/ directory into Sigma's include/.
+6. Copy `out/Release/obj.target/libcef_dll_wrapper.a` (or .lib) to `Sigma/cef/`
+7. This step also depends on your platform.
+    * __Windows__ copy all the .dll files in `Release/` to `Sigma/cef/bin`, then copy the .lib file into `Sigma/cef/`
+    * __Linux__ or __OS X__ copy the entire contents of `Release/` into `Sigma/cef/bin/`
+8. On Linux and OSX, make a symlink pointing to libcef.so (or .dylib) in the `cef/` directory.
+9. If you get the error "malformed archive" when building, make a symlink pointing to `libcef_dll_wrapper` directory in the `cef/` directory.
 
 ## Building ##
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ You'll also need a [package of assets](http://wiki.trillek.org/wiki/Assets).  Un
 Make sure you use a binary release from [Adobe](http://www.cefbuilds.com). **Use the latest version that is NOT marked as dev (trunk).**
 
 1. Unzip the downloaded tarball.
-2. This step depends on your platform. 
+2. This step depends on your platform. **Make sure to use the Release build mode.**
     * __Windows__ build the included `libcef_dll_wrapper.vcxproj` project
     * __Linux__ run `make libcef_dll_wrapper BUILDTYPE=Release`
-    * __OS X__ use the `cefclient.xcodeproj` Xcode project. **Make sure to use the Release build mode.**
+    * __OS X__ use the `cefclient.xcodeproj` Xcode project.
 3. Make `cef/` and `cef/bin/` directories in `Sigma/`
 4. Copy the `out/Release/obj.target/libcef_dll_wrapper` directory, if any, and the contents of `Resources/` directories into `Sigma/cef/bin/`
 5. Copy the contents of include/ directory into Sigma's include/.
@@ -49,7 +49,7 @@ Make sure you use a binary release from [Adobe](http://www.cefbuilds.com). **Use
     * __Windows__ copy all the .dll files in `Release/` to `Sigma/cef/bin`, then copy the .lib file into `Sigma/cef/`
     * __Linux__ or __OS X__ copy the entire contents of `Release/` into `Sigma/cef/bin/`
 8. On Linux and OSX, make a symlink pointing to libcef.so (or .dylib) in the `cef/` directory.
-9. If you get the error "malformed archive" when building, make a symlink pointing to `libcef_dll_wrapper` directory in the `cef/` directory.
+9. Make a symlink pointing to `Sigma/cef/bin/libcef_dll_wrapper` in the `cef/` directory. `libcef_dll_wrapper` and `libcef_dll_wrapper.a` must appear in the same place, otherwise you will get a "Malformed Archive" error when linking.
 
 ## Building ##
 

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -97,7 +97,7 @@ int main(int argCount, char **argValues) {
 	std::cout << "Initializing OpenAL system." << std::endl;
 	alsys.Start();
 	alsys.test(); // try sound
-	
+
 	////////////////
 	// Load scene //
 	////////////////
@@ -168,7 +168,7 @@ int main(int argCount, char **argValues) {
 	glfwos.RegisterKeyboardEventHandler(&theCamera);
 	glfwos.RegisterMouseEventHandler(&theCamera);
 	theCamera.os = &glfwos;
-	
+
 	// Sync bullet physics object with gl camera
 
 	///////////////////
@@ -179,7 +179,7 @@ int main(int argCount, char **argValues) {
 	guicon.SetGUI(webguisys.getComponent(100, Sigma::WebGUIView::getStaticComponentTypeName()));
 	glfwos.RegisterKeyboardEventHandler(&guicon);
 	glfwos.RegisterMouseEventHandler(&guicon);
-	
+
 	// Call now to clear the delta after startup.
 	glfwos.GetDeltaTime();
 	{


### PR DESCRIPTION
`cef/` is ignored by git

Because my workflow involves removing `build/` frequently, I changed the CEF requirements to put things in `cef/bin` which are copied to `build/bin`, rather than keeping CEF things in `build/bin/` directly

Readme is updated to reflect this
