### PR TITLE
Fix Logger with VS2010

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ SET(CMAKE_INCLUDE_PATH
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/build/bin)
 
 # Set the directory of Find<Library>.cmake modules
-SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/modules")
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/modules")
 
 # find all source files in the src directory
 FILE(GLOB Sigma_SRC "src/*.cpp")

--- a/include/Log.h
+++ b/include/Log.h
@@ -17,17 +17,32 @@
 #include <memory>
 #include <cassert>
 
+// MS Visual C++ stuff
+#if defined(_MSC_VER)
+	// VC++ C compiler support : C89 thanks microsoft !
+	#define snprintf _snprintf 
+        
+	// Get bored of theses warnings
+	#pragma warning(disable : 4996) // Ni puñetera idea
+	#pragma warning(disable : 4333) // Shift warning execding output var size, data loss
+	#pragma warning(disable : 4018) // Comparation of signed and unsigned with auto conversion
+	#pragma warning(disable : 4244) // Conversion of variables with data loss
+
+  #pragma warning(disable : 4482) // Not standard extension : Using full name of a enumeration
+#endif
+
+
 namespace Log {
 
 	/**
 	 * Logging levels
 	 */
 	enum LogLevel {
-		OFF = -1,
-		ERROR = 0,
-		WARN = 1,
-		INFO = 2,
-		DEBUG = 3,
+		LOGG_OFF		= -1,
+		LOGG_ERROR = 0,
+		LOGG_WARN	= 1,
+		LOGG_INFO	= 2,
+		LOGG_DEBUG = 3,
 	};
 
 
@@ -55,7 +70,7 @@ namespace Log {
 			 * \param level Logger level. By default it is at Debug level
 			 * \param sout Output Streambuffer where to write. By default uses std::clog
 			 */
-			static void Init(LogLevel level = LogLevel::DEBUG) {
+			static void Init(LogLevel level = LogLevel::LOGG_DEBUG) {
 				log_level = level;
 				out = &std::clog;
 			}
@@ -65,7 +80,7 @@ namespace Log {
 			 * \param level Logger level. By default it is at Debug level
 			 * \param sout Output Streambuffer where to write. By default uses std::clog
 			 */
-			static void Init(std::ostream& sout, LogLevel level = LogLevel::DEBUG) {
+			static void Init(std::ostream& sout, LogLevel level = LogLevel::LOGG_DEBUG) {
 				log_level = level;
 				out = &sout;
 			}
@@ -86,19 +101,19 @@ namespace Log {
 
 					if( output ) {
 						switch (level) {
-							case LogLevel::ERROR:
+							case LogLevel::LOGG_ERROR:
 								*out << "[ERROR] ";
 								break;
 
-							case LogLevel::WARN:
+							case LogLevel::LOGG_WARN:
 								*out << "[WARNING] ";
 								break;
 
-							case LogLevel::INFO:
+							case LogLevel::LOGG_INFO:
 								*out << "[INFO] ";
 								break;
 
-							case LogLevel::DEBUG:
+							case LogLevel::LOGG_DEBUG:
 								*out << "[DEBUG] ";
 								break;
 
@@ -147,10 +162,10 @@ namespace Log {
 } // END OF NAMESPACE logger
 
 // Macros to type less
-#define LOG_DEBUG Log::Print(Log::LogLevel::DEBUG)
-#define LOG       Log::Print(Log::LogLevel::INFO)
-#define LOG_WARN  Log::Print(Log::LogLevel::WARN)
-#define LOG_ERROR Log::Print(Log::LogLevel::ERROR)
+#define LOG_DEBUG Log::Print(Log::LogLevel::LOGG_DEBUG)
+#define LOG       Log::Print(Log::LogLevel::LOGG_INFO)
+#define LOG_WARN  Log::Print(Log::LogLevel::LOGG_WARN)
+#define LOG_ERROR Log::Print(Log::LogLevel::LOGG_ERROR)
 
 
 #endif // __LOGGER_H_

--- a/src/tests/Log.cpp
+++ b/src/tests/Log.cpp
@@ -17,7 +17,7 @@ int main () {
 		LOG_WARN	<< "Hello world!";
 		LOG_ERROR << "Hello world!";
 
-		Log::Print::Level(Log::LogLevel::WARN);	
+		Log::Print::Level(Log::LogLevel::LOGG_WARN);	
 		LOG_DEBUG << "Hello world! 2";
 		LOG				<< "Hello world! 2";
 		LOG_WARN	<< "Hello world! 2";
@@ -54,7 +54,7 @@ int main () {
 	LOG_ERROR << "String : " << str1;
 	LOG_ERROR << "String : " << path << filename;
 
-	Log::Print::Level(Log::LogLevel::WARN);	
+	Log::Print::Level(Log::LogLevel::LOGG_WARN);	
 	LOG_DEBUG << "You shouldn't see this";
 	LOG				<< "Too verbose...";
 	LOG_WARN	<< "Alarm!";


### PR DESCRIPTION
Remove stupid warnings of VS2010 and fix a few errors.
At least is working when Sigma is being build as static lib. Tested with VS2010
